### PR TITLE
Sync child supertables with group header

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday-group-detail.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday-group-detail.component.ts
@@ -1,4 +1,10 @@
-import { Component, Input, OnInit, TemplateRef } from '@angular/core';
+import {
+  Component,
+  Input,
+  OnInit,
+  TemplateRef,
+  ViewChild,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Observable } from 'rxjs';
 
@@ -23,6 +29,7 @@ export class BirthdayGroupDetailComponent implements OnInit {
   @Input() expandedRowTemplate: TemplateRef<any> | undefined;
 
   dataLoader: DataLoader<IBirthday>;
+  @ViewChild(SuperTable) superTableComponent!: SuperTable;
 
   constructor(private birthdayService: BirthdayService) {
     const fetchFunction: FetchFunction<IBirthday> = (queryParams: any) => {
@@ -34,5 +41,13 @@ export class BirthdayGroupDetailComponent implements OnInit {
   ngOnInit(): void {
     const filter = { query: `fname:"${this.groupName}"` };
     this.dataLoader.load(50, 'lname', true, filter);
+  }
+
+  applySort(event: any): void {
+    this.superTableComponent.applySort(event);
+  }
+
+  applyFilter(event: any): void {
+    this.superTableComponent.applyFilter(event);
   }
 }

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
@@ -56,7 +56,8 @@
 
   <ng-container *ngIf="viewMode === 'group'">
     <div class="table-responsive" style="flex: 1; display: flex; flex-direction: column; min-height: 0;">
-      <super-table [columns]="columns" [showHeader]="true" [superTableParent]="this" [dataLoader]="headerDataLoader" [resizableColumns]="true"></super-table>
+      <super-table #headerTable [columns]="columns" [showHeader]="true" [superTableParent]="this" [dataLoader]="headerDataLoader" [resizableColumns]="true"
+                   (onSort)="onHeaderSort($event)" (onFilter)="onHeaderFilter($event)" (onColResize)="onHeaderColResize($event)"></super-table>
       <div style="overflow-y: auto; flex: 1;">
         <div *ngFor="let groupName of (groups$ | async)">
           <div class="group-header" (click)="onGroupToggle(groupName)">

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */ 
 
-import { Component, OnInit, ViewChild, ElementRef, TemplateRef } from '@angular/core';
+import { Component, OnInit, ViewChild, ViewChildren, QueryList, ElementRef, TemplateRef } from '@angular/core';
 import { HttpHeaders, HttpResponse } from '@angular/common/http';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { combineLatest, BehaviorSubject, Subscription, Observable, of } from 'rxjs';
@@ -58,6 +58,8 @@ export class BirthdayComponent implements OnInit {
   @ViewChild('searchInput') searchInput!: ElementRef<HTMLInputElement>;
   @ViewChild('menu') menu!: Menu;
   @ViewChild('expandedRow', { static: true }) expandedRowTemplate: TemplateRef<any> | undefined;
+  @ViewChild('headerTable') headerTable!: SuperTable;
+  @ViewChildren(BirthdayGroupDetailComponent) groupDetailComponents!: QueryList<BirthdayGroupDetailComponent>;
 
   dataLoader: DataLoader<IBirthday>;
   headerDataLoader: DataLoader<IBirthday>;
@@ -380,5 +382,23 @@ export class BirthdayComponent implements OnInit {
 
   logSort(event: any): void {
     console.log('sort event', event);
+  }
+
+  onHeaderSort(event: any): void {
+    this.groupDetailComponents?.forEach(cmp => cmp.applySort(event));
+  }
+
+  onHeaderFilter(event: any): void {
+    this.groupDetailComponents?.forEach(cmp => cmp.applyFilter(event));
+  }
+
+  onHeaderColResize(event: any): void {
+    if (event?.element) {
+      const index = event.element.cellIndex;
+      const newWidth = event.element.offsetWidth + 'px';
+      if (this.columns[index]) {
+        this.columns[index].width = newWidth;
+      }
+    }
   }
 }

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
@@ -12,6 +12,8 @@
   [scrollHeight]="scrollHeight"
   [paginator]="paginator"
   (onSort)="onSort.emit($event)"
+  (onFilter)="onFilter.emit($event)"
+  (onColResize)="onColResize.emit($event)"
   expandableRow
   [expandedRowKeys]="expandedRowKeys"
   (onRowExpand)="onRowExpand($event)"
@@ -125,7 +127,7 @@
 </p-table>
 
 <div *ngIf="displayMode === 'group' && dataLoader">
-  <p-table [columns]="columns" [value]="[]" *ngIf="showHeader" styleClass="p-datatable-gridlines" (onSort)="onSort.emit($event)">
+  <p-table [columns]="columns" [value]="[]" *ngIf="showHeader" styleClass="p-datatable-gridlines" (onSort)="onSort.emit($event)" (onFilter)="onFilter.emit($event)" (onColResize)="onColResize.emit($event)">
     <ng-template pTemplate="header" let-columns>
       <tr class="header-row">
         <th *ngFor="let col of columns"

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
@@ -73,6 +73,7 @@ export class SuperTable implements OnInit {
     @Output() onContextMenuSelect = new EventEmitter<any>();
     @Output() onColResize = new EventEmitter<any>();
     @Output() onSort = new EventEmitter<any>();
+    @Output() onFilter = new EventEmitter<any>();
 
     ngOnInit(): void {
       if (!this.superTableParent) {
@@ -121,6 +122,25 @@ export class SuperTable implements OnInit {
         this.pTable.filter(null, field, 'in');
       } else {
         this.pTable.filter(selectedValues, field, 'in');
+      }
+    }
+
+    applySort(event: any): void {
+      if (this.pTable && event) {
+        (this.pTable as any).sortField = event.sortField || event.field;
+        (this.pTable as any).sortOrder = event.sortOrder || event.order;
+        if ((this.pTable as any).sortSingle) {
+          (this.pTable as any).sortSingle();
+        }
+      }
+    }
+
+    applyFilter(event: any): void {
+      if (this.pTable && event?.filters) {
+        (this.pTable as any).filters = event.filters;
+        if ((this.pTable as any)._filter) {
+          (this.pTable as any)._filter();
+        }
       }
     }
 }

--- a/src/JhipsterSampleApplication/ClientApp/test/cypress/support/management.ts
+++ b/src/JhipsterSampleApplication/ClientApp/test/cypress/support/management.ts
@@ -1,13 +1,12 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 
-import { Interception } from 'cypress/types/net-stubbing';
-
-const getManagementInfo = (cy: Cypress.cy, selector: string): any => cy.get(selector);
+const getManagementInfo = (cy: Cypress.cy, selector: string): any =>
+  cy.get(selector);
 
 const getPageTestId = (selector: string): string => `[data-cy="${selector}"]`;
 
-const getSelector = (selector: string, testId?: string): any => cy.get(testId ? getPageTestId(testId) : selector);
+const getSelector = (selector: string, testId?: string): any =>
+  cy.get(testId ? getPageTestId(testId) : selector);
 
 export const managementInfo = {
   getManagementInfo,


### PR DESCRIPTION
## Summary
- propagate resize, filter and sort events from the group header table
- update child tables when header changes occur
- expose helper methods on SuperTable
- clean up lint issues

## Testing
- `npm run lint -w src/JhipsterSampleApplication/ClientApp -- --fix`
- `npm test -w src/JhipsterSampleApplication/ClientApp/` *(fails: Selector tests)*

------
https://chatgpt.com/codex/tasks/task_e_685c118a48348321a120c7e75d8a4b5e