### PR TITLE
Fix column resize mode

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
@@ -396,16 +396,23 @@ export class BirthdayComponent implements OnInit {
   onHeaderColResize(event: TableColResizeEvent): void {
     if (event?.element) {
       const index = (event.element as any).cellIndex;
-      const newWidth = event.element.offsetWidth + 'px';
+      const newWidthPx = event.element.offsetWidth + 'px';
+      const newWidth = event.element.offsetWidth;
       if (this.columns[index]) {
-        this.columns[index].width = newWidth;
+        this.columns[index].width = newWidthPx;
         this.columns = [...this.columns];
       }
+
+      // Update style of header table immediately
+      const headerWidths = this.columns.map(c => parseInt(c.width || '0', 10));
+      (this.headerTable.pTable as any).updateStyleElement(headerWidths, index, newWidth, null);
     }
 
     // Propagate updated column definitions to child tables via Input binding
     this.groupDetailComponents?.forEach(cmp => {
       cmp.columns = [...this.columns];
+      const childWidths = cmp.columns.map(c => parseInt(c.width || '0', 10));
+      (cmp.superTableComponent.pTable as any).updateStyleElement(childWidths, index, newWidth, null);
     });
   }
 }

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
@@ -6,7 +6,7 @@
   [columns]="columns"
   dataKey="id"
   [resizableColumns]="resizableColumns"
-  columnResizeMode="fit"
+  [columnResizeMode]="columnResizeMode"
   [reorderableColumns]="reorderableColumns"
   [scrollable]="scrollable"
   [scrollHeight]="scrollHeight"
@@ -127,7 +127,9 @@
 </p-table>
 
 <div *ngIf="displayMode === 'group' && dataLoader">
-  <p-table [columns]="columns" [value]="[]" *ngIf="showHeader" styleClass="p-datatable-gridlines" (onSort)="onSort.emit($event)" (onFilter)="onFilter.emit($event)" (onColResize)="onColResize.emit($event)">
+  <p-table [columns]="columns" [value]="[]" *ngIf="showHeader" styleClass="p-datatable-gridlines"
+           [resizableColumns]="resizableColumns" [columnResizeMode]="columnResizeMode"
+           (onSort)="onSort.emit($event)" (onFilter)="onFilter.emit($event)" (onColResize)="onColResize.emit($event)">
     <ng-template pTemplate="header" let-columns>
       <tr class="header-row">
         <th *ngFor="let col of columns"

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
@@ -46,6 +46,7 @@ export class SuperTable implements OnInit {
     @Input() displayMode: 'grid' | 'group' = 'grid';
     @Input() loading = false;
     @Input() resizableColumns = false;
+    @Input() columnResizeMode: 'fit' | 'expand' = 'expand';
     @Input() reorderableColumns = false;
     @Input() scrollable = false;
     @Input() scrollHeight: string | undefined;


### PR DESCRIPTION
## Summary
- default to expanding columns when resizing
- apply column width updates to header and child tables right away

## Testing
- `npm test` *(fails: Selector component test issues)*

------
https://chatgpt.com/codex/tasks/task_e_685c5e0c38c883219ed53f9770dc3b7d