### PR TITLE
Add simple column reorder handling

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
@@ -40,6 +40,7 @@
       (selectionChange)="onCheckboxChange()"
       (onContextMenuSelect)="setMenu($event.data)"
       (contextMenuSelectionChange)="onContextMenuSelect($event)"
+      (onColReorder)="onColumnReorder($event)"
     ></super-table>
   </div>
 
@@ -57,7 +58,7 @@
   <ng-container *ngIf="viewMode === 'group'">
     <div class="table-responsive" style="flex: 1; display: flex; flex-direction: column; min-height: 0;">
       <super-table #headerTable [columns]="columns" [showHeader]="true" [superTableParent]="this" [dataLoader]="headerDataLoader" [resizableColumns]="true"
-                   (onSort)="onHeaderSort($event)" (onFilter)="onHeaderFilter($event)" (onColResize)="onHeaderColResize($event)"></super-table>
+                   (onSort)="onHeaderSort($event)" (onFilter)="onHeaderFilter($event)" (onColResize)="onHeaderColResize($event)" (onColReorder)="onColumnReorder($event)"></super-table>
       <div style="overflow-y: auto; flex: 1;">
         <div *ngFor="let groupName of (groups$ | async)">
           <div class="group-header" (click)="onGroupToggle(groupName)">

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
@@ -31,7 +31,7 @@ import {
 } from '../../../shared/SuperTable/super-table.component';
 import { DataLoader, FetchFunction } from 'app/shared/data-loader';
 import { BirthdayGroupDetailComponent } from './birthday-group-detail.component';
-import { TableColResizeEvent } from 'primeng/table';
+import { TableColResizeEvent, TableColumnReorderEvent } from 'primeng/table';
 
 import { ITEMS_PER_PAGE, PAGE_HEADER, TOTAL_COUNT_RESPONSE_HEADER } from 'app/config/pagination.constants';
 import { ASC, DESC, SORT, ITEM_DELETED_EVENT, DEFAULT_SORT_DATA } from 'app/config/navigation.constants';
@@ -413,6 +413,21 @@ export class BirthdayComponent implements OnInit {
       cmp.columns = [...this.columns];
       const childWidths = cmp.columns.map(c => parseInt(c.width || '0', 10));
       (cmp.superTableComponent.pTable as any).updateStyleElement(childWidths, index, newWidth, null);
+    });
+  }
+
+  onColumnReorder(event: TableColumnReorderEvent): void {
+    if (event.dragIndex == null || event.dropIndex == null) {
+      return;
+    }
+
+    const cols = [...this.columns];
+    const moved = cols.splice(event.dragIndex, 1)[0];
+    cols.splice(event.dropIndex, 0, moved);
+    this.columns = cols;
+
+    this.groupDetailComponents?.forEach(cmp => {
+      cmp.columns = [...this.columns];
     });
   }
 }


### PR DESCRIPTION
## Summary
- handle column reorder events in BirthdayComponent
- wire column reorder events to grid and header tables

## Testing
- `npm test` *(fails: Selector component tests)*
- `dotnet test` *(fails: npm build errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c785cd03c83219a63204e823eebe8