### PR TITLE
Fix column resizing after switching modes

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
@@ -8,7 +8,7 @@
         <span>Refresh List</span>
       </button>
 
-      <button class="btn btn-primary" (click)="viewMode = viewMode === 'grid' ? 'group' : 'grid'">
+      <button class="btn btn-primary" (click)="toggleViewMode()">
         <fa-icon icon="eye"></fa-icon>
         <span>{{ viewMode === 'grid' ? 'Group View' : 'Grid View' }}</span>
       </button>

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
@@ -408,4 +408,11 @@ export class BirthdayComponent implements OnInit {
       cmp.columns = [...this.columns];
     });
   }
+
+  toggleViewMode(): void {
+    this.viewMode = this.viewMode === 'grid' ? 'group' : 'grid';
+    if (this.viewMode === 'grid') {
+      this.columns = this.columns.map(col => ({ ...col }));
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add `toggleViewMode` method to force column refresh when switching views
- wire up the view toggle button to call the new method

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c82548af483219874171cb87b901c