### PR TITLE
Remove GroupDetailComponent from imports

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
@@ -49,7 +49,6 @@ import { ASC, DESC, SORT, ITEM_DELETED_EVENT, DEFAULT_SORT_DATA } from 'app/conf
     SharedModule,
     SuperTable,
     TableModule,
-    GroupDetailComponent,
   ],
   standalone: true,
 })


### PR DESCRIPTION
## Summary
- adjust birthday.component to omit GroupDetailComponent from the imports array

## Testing
- `npm run prettier:check` *(fails: code style issues found)*
- `npm test` *(fails: 5 failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_685d5c571e808321ac146c7b8f5c17c1