### PR TITLE
Fix SuperTable groups type

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
@@ -44,7 +44,8 @@ export interface ColumnConfig {
 export class SuperTable implements OnInit {
     @Input() dataLoader: DataLoader<any> | undefined;
     @Input() columns: ColumnConfig[] = [];
-    @Input() groups: string[] | undefined;
+    // groups can be undefined or null when asynchronously loaded
+    @Input() groups: string[] | null | undefined;
     @Input() groupQuery: ((group: string) => DataLoader<any>) | undefined;
     @Input() mode: 'grid' | 'group' = 'grid';
     @Input() loading = false;


### PR DESCRIPTION
## Summary
- allow `null` as a valid value for `groups` input

## Testing
- `npm test` *(fails: Selector specs can't resolve standalone components)*
- `dotnet test --no-build --logger "console;verbosity=quiet"` *(fails to run due to environment restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685d5cd5e71083219b44bf21879c0015