### PR TITLE
Integrate grouping into SuperTable

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
@@ -28,11 +28,15 @@
   <jhi-alert-error></jhi-alert-error>
   <jhi-alert></jhi-alert>
 
-  <div class="table-responsive" *ngIf="viewMode === 'grid'" style="flex: 1; min-height: 0">
+  <div class="table-responsive" style="flex: 1; min-height: 0">
     <super-table
+      #superTable
       class="grid-table"
       [dataLoader]="dataLoader"
       [columns]="columns"
+      [mode]="viewMode"
+      [groups]="groups"
+      [groupQuery]="groupQuery.bind(this)"
       [superTableParent]="this"
       [resizableColumns]="true"
       [scrollable]="true"
@@ -40,6 +44,7 @@
       (selectionChange)="onCheckboxChange()"
       (onContextMenuSelect)="setMenu($event.data)"
       (contextMenuSelectionChange)="onContextMenuSelect($event)"
+      [expandedRowTemplate]="expandedRow"
     ></super-table>
   </div>
 
@@ -54,23 +59,7 @@
     </tr>
   </ng-template>
 
-  <ng-container *ngIf="viewMode === 'group'">
-    <div class="table-responsive" style="flex: 1; display: flex; flex-direction: column; min-height: 0;">
-      <super-table #headerTable [columns]="columns" [showHeader]="true" [superTableParent]="this" [dataLoader]="headerDataLoader" [resizableColumns]="true"
-                   (onSort)="onHeaderSort($event)" (onFilter)="onHeaderFilter($event)" (onColResize)="onHeaderColResize($event)"></super-table>
-      <div style="overflow-y: auto; flex: 1;">
-        <div *ngFor="let groupName of (groups$ | async)">
-          <div class="group-header" (click)="onGroupToggle(groupName)">
-            <span [class]="isGroupExpanded(groupName) ? 'pi pi-chevron-down' : 'pi pi-chevron-right'"></span>
-            {{ groupName }}
-          </div>
-          <div *ngIf="isGroupExpanded(groupName)">
-            <jhi-birthday-group-detail [groupName]="groupName" [columns]="columns" [parent]="this" [expandedRowTemplate]="expandedRow"></jhi-birthday-group-detail>
-          </div>
-        </div>
-      </div>
-    </div>
-  </ng-container>
+
 
   <p-contextMenu #contextMenu [model]="menuItems" (onShow)="onMenuShow($event, 'context')"></p-contextMenu>
 

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
@@ -1,6 +1,6 @@
 <!-- super-table.component.html -->
 <p-table
-  *ngIf="dataLoader && displayMode === 'grid'"
+  *ngIf="dataLoader && mode === 'grid'"
   #pTable
   [value]="(dataLoader.data$ | async)!"
   [columns]="columns"
@@ -126,8 +126,8 @@
   </ng-template>
 </p-table>
 
-<div *ngIf="displayMode === 'group' && dataLoader">
-  <p-table [columns]="columns" [value]="[]" *ngIf="showHeader" styleClass="p-datatable-gridlines" (onSort)="onSort.emit($event)" (onFilter)="onFilter.emit($event)" (onColResize)="onColResize.emit($event)">
+<div *ngIf="mode === 'group'">
+  <p-table [columns]="columns" [value]="[]" *ngIf="showHeader" styleClass="p-datatable-gridlines" (onSort)="onHeaderSort($event)" (onFilter)="onHeaderFilter($event)" (onColResize)="onHeaderColResize($event)">
     <ng-template pTemplate="header" let-columns>
       <tr class="header-row">
         <th *ngFor="let col of columns"
@@ -192,7 +192,7 @@
       </tr>
     </ng-template>
   </p-table>
-  <p-table [value]="(dataLoader.data$ | async)!" styleClass="p-datatable-gridlines">
+  <p-table [value]="groups" styleClass="p-datatable-gridlines">
     <ng-template pTemplate="body" let-rowData>
       <tr class="p-row-odd">
         <td style="width: 3rem; text-align: center;">
@@ -205,7 +205,18 @@
       </tr>
       <tr *ngIf="isGroupExpanded(rowData)">
         <td [attr.colspan]="2">
-            <ng-container *ngTemplateOutlet="expandedRowTemplate ?? null; context: { $implicit: rowData }"></ng-container>
+          <super-table
+            #detailTable
+            [dataLoader]="groupLoaders[rowData]"
+            [columns]="columns"
+            [mode]="'grid'"
+            [superTableParent]="superTableParent"
+            [showHeader]="false"
+            [expandedRowTemplate]="expandedRowTemplate"
+            [resizableColumns]="resizableColumns"
+            [scrollable]="scrollable"
+            [scrollHeight]="scrollHeight"
+          ></super-table>
         </td>
       </tr>
     </ng-template>


### PR DESCRIPTION
## Summary
- support group view directly in `SuperTable`
- simplify `BirthdayComponent` to use new group mode
- add `groupQuery` hook for retrieving grouped data

## Testing
- `npm run webapp:build:dev`

------
https://chatgpt.com/codex/tasks/task_e_685d6400629883219c415b886694248c