### PR TITLE
Fix group mode sticky headers

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
@@ -127,7 +127,7 @@
 </p-table>
 
 <div *ngIf="mode === 'group'">
-  <p-table [columns]="columns" [value]="[]" *ngIf="showHeader" styleClass="p-datatable-gridlines" (onSort)="onHeaderSort($event)" (onFilter)="onHeaderFilter($event)" (onColResize)="onHeaderColResize($event)">
+  <p-table [columns]="columns" [value]="[]" *ngIf="showHeader" styleClass="p-datatable-gridlines group-header-table" (onSort)="onHeaderSort($event)" (onFilter)="onHeaderFilter($event)" (onColResize)="onHeaderColResize($event)">
     <ng-template pTemplate="header" let-columns>
       <tr class="header-row">
         <th *ngFor="let col of columns"

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.scss
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.scss
@@ -20,4 +20,13 @@
   .pi {
     font-family: "PrimeIcons" !important;
   }
-} 
+}
+
+.group-header-table {
+  ::ng-deep .p-datatable-thead > tr {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: inherit;
+  }
+}


### PR DESCRIPTION
## Summary
- keep headers visible when scrolling in group mode

## Testing
- `npm test` *(fails: Selector component unit tests)*
- `npx prettier -c src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.scss`

------
https://chatgpt.com/codex/tasks/task_e_685d6f39a0a88321bd60a220724f7fe5