### PR TITLE
Fix sticky header in group mode

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.scss
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.scss
@@ -23,7 +23,7 @@
 }
 
 .group-header-table {
-  ::ng-deep .p-datatable-thead > tr {
+  ::ng-deep .p-datatable-thead > tr > th {
     position: sticky;
     top: 0;
     z-index: 1;


### PR DESCRIPTION
## Summary
- ensure the SuperTable group mode header uses sticky positioning on table header cells

## Testing
- `npm test` *(fails: Selector component specs)*

------
https://chatgpt.com/codex/tasks/task_e_685d7bb6a9c0832180a4afcb168be55a