### PR TITLE
Fix group mode scrolling in SuperTable

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
@@ -126,7 +126,7 @@
   </ng-template>
 </p-table>
 
-<div *ngIf="mode === 'group'">
+<div *ngIf="mode === 'group'" class="group-mode-wrapper">
   <p-table [columns]="columns" [value]="[]" *ngIf="showHeader" styleClass="p-datatable-gridlines" (onSort)="onHeaderSort($event)" (onFilter)="onHeaderFilter($event)" (onColResize)="onHeaderColResize($event)">
     <ng-template pTemplate="header" let-columns>
       <tr class="header-row">
@@ -192,7 +192,8 @@
       </tr>
     </ng-template>
   </p-table>
-  <p-table [value]="groups" styleClass="p-datatable-gridlines">
+  <div class="group-table-body" [style.max-height]="scrollHeight">
+    <p-table [value]="groups" styleClass="p-datatable-gridlines">
     <ng-template pTemplate="body" let-rowData>
       <tr class="p-row-odd">
         <td style="width: 3rem; text-align: center;">
@@ -220,5 +221,6 @@
         </td>
       </tr>
     </ng-template>
-  </p-table>
+    </p-table>
+  </div>
 </div>

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.scss
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.scss
@@ -20,4 +20,8 @@
   .pi {
     font-family: "PrimeIcons" !important;
   }
-} 
+
+  .group-table-body {
+    overflow-y: auto;
+  }
+}


### PR DESCRIPTION
## Summary
- keep column headers stationary in `group` mode of SuperTable by wrapping body in scrolling div
- add overflow styling for new wrapper

## Testing
- `npm test -w src/JhipsterSampleApplication/ClientApp/` *(fails: Selector tests)*

------
https://chatgpt.com/codex/tasks/task_e_685d8877af88832192165e04e952d6a6