### PR TITLE
Handle SuperTable mode changes

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
@@ -273,12 +273,12 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
   }
 
   private initGroupScroll(): void {
-    const body = (this.pTable?.el?.nativeElement as HTMLElement)?.querySelector(
-      '.p-datatable-scrollable-body',
-    );
+    const body =
+      (this.pTable?.scroller?.getElementRef()?.nativeElement as HTMLElement) ||
+      (this.pTable?.wrapperViewChild?.nativeElement as HTMLElement);
     if (body) {
       this.destroyGroupScroll();
-      this.scrollContainer = body as HTMLElement;
+      this.scrollContainer = body;
       this.scrollContainer.addEventListener('scroll', this.scrollListener);
       this.captureTopGroup();
     }

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
@@ -1,6 +1,21 @@
-/* eslint-disable */ 
+/* eslint-disable */
 
-import { Component, Input, Output, EventEmitter, ContentChild, TemplateRef, ViewChild, OnInit, ViewChildren, QueryList, AfterViewInit, OnDestroy } from '@angular/core';
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  ContentChild,
+  TemplateRef,
+  ViewChild,
+  OnInit,
+  ViewChildren,
+  QueryList,
+  AfterViewInit,
+  OnDestroy,
+  OnChanges,
+  SimpleChanges,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
@@ -18,7 +33,14 @@ export interface ColumnConfig {
   filterType?: 'text' | 'date' | 'numeric' | 'boolean';
   width?: string;
   style?: string;
-  type?: 'checkbox' | 'expander' | 'string' | 'date' | 'boolean' | 'list' | 'lineNumber';
+  type?:
+    | 'checkbox'
+    | 'expander'
+    | 'string'
+    | 'date'
+    | 'boolean'
+    | 'list'
+    | 'lineNumber';
   dateFormat?: string;
   listOptions?: { label: string; value: string }[];
 }
@@ -39,48 +61,49 @@ export interface ColumnConfig {
     FormsModule,
   ],
 })
-export class SuperTable implements OnInit, AfterViewInit, OnDestroy {
-    @Input() dataLoader: DataLoader<any> | undefined;
-    @Input() columns: ColumnConfig[] = [];
-    @Input() groups: string[] = [];
-    @Input() mode: 'grid' | 'group' = 'grid';
-    @Input() groupQuery: ((groupName: string) => DataLoader<any>) | undefined;
-    @Input() loading = false;
-    @Input() resizableColumns = false;
-    @Input() reorderableColumns = false;
-    @Input() scrollable = false;
-    @Input() scrollHeight: string | undefined;
-    @Input() paginator = false;
-    @Input() showHeader = true;
-    @Input() dataKey: string | undefined;
-    @Input() globalFilterFields: string[] = [];
-    @Input() contextMenuSelection: any;
-    @Input() contextMenu: any;
-    @Input() selectionMode: 'single' | 'multiple' | null | undefined;
-    @Input() selection: any;
-    @Input() expandedRowKeys: { [key: string]: boolean } = {};
-    @Input() loadingMessage: string | undefined;
-    @Input() superTableParent: any;
-    @Input() expandedRowTemplate: TemplateRef<any> | undefined;
+export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
+  @Input() dataLoader: DataLoader<any> | undefined;
+  @Input() columns: ColumnConfig[] = [];
+  @Input() groups: string[] = [];
+  @Input() mode: 'grid' | 'group' = 'grid';
+  @Input() groupQuery: ((groupName: string) => DataLoader<any>) | undefined;
+  @Input() loading = false;
+  @Input() resizableColumns = false;
+  @Input() reorderableColumns = false;
+  @Input() scrollable = false;
+  @Input() scrollHeight: string | undefined;
+  @Input() paginator = false;
+  @Input() showHeader = true;
+  @Input() dataKey: string | undefined;
+  @Input() globalFilterFields: string[] = [];
+  @Input() contextMenuSelection: any;
+  @Input() contextMenu: any;
+  @Input() selectionMode: 'single' | 'multiple' | null | undefined;
+  @Input() selection: any;
+  @Input() expandedRowKeys: { [key: string]: boolean } = {};
+  @Input() loadingMessage: string | undefined;
+  @Input() superTableParent: any;
+  @Input() expandedRowTemplate: TemplateRef<any> | undefined;
 
-    @ViewChild('pTable') pTable!: Table;
-    @ViewChildren('detailTable') detailTables!: QueryList<SuperTable>;
+  @ViewChild('pTable') pTable!: Table;
+  @ViewChildren('detailTable') detailTables!: QueryList<SuperTable>;
 
-    groupLoaders: { [key: string]: DataLoader<any> } = {};
+  groupLoaders: { [key: string]: DataLoader<any> } = {};
 
-    private scrollContainer?: HTMLElement;
-    private topGroupName?: string;
-    private scrollListener = () => this.captureTopGroup();
+  private scrollContainer?: HTMLElement;
+  private topGroupName?: string;
+  private scrollListener = () => this.captureTopGroup();
 
-    @ContentChild('customHeader', { read: TemplateRef }) headerTemplate?: TemplateRef<any>;
-    
-    @Output() rowExpand = new EventEmitter<any>();
-    @Output() rowCollapse = new EventEmitter<any>();
-    @Output() selectionChange = new EventEmitter<any>();
-    @Output() contextMenuSelectionChange = new EventEmitter<any>();
-    @Output() onContextMenuSelect = new EventEmitter<any>();
-    @Output() onColResize = new EventEmitter<any>();
-    @Output() onSort = new EventEmitter<any>();
+  @ContentChild('customHeader', { read: TemplateRef })
+  headerTemplate?: TemplateRef<any>;
+
+  @Output() rowExpand = new EventEmitter<any>();
+  @Output() rowCollapse = new EventEmitter<any>();
+  @Output() selectionChange = new EventEmitter<any>();
+  @Output() contextMenuSelectionChange = new EventEmitter<any>();
+  @Output() onContextMenuSelect = new EventEmitter<any>();
+  @Output() onColResize = new EventEmitter<any>();
+  @Output() onSort = new EventEmitter<any>();
   @Output() onFilter = new EventEmitter<any>();
 
   ngOnInit(): void {
@@ -89,79 +112,82 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['mode'] && !changes['mode'].firstChange) {
+      if (changes['mode'].currentValue === 'group') {
+        setTimeout(() => this.initGroupScroll());
+      } else {
+        this.destroyGroupScroll();
+      }
+    }
+  }
+
   ngAfterViewInit(): void {
     if (this.mode === 'group') {
-      const body = (this.pTable?.el?.nativeElement as HTMLElement)?.querySelector(
-        '.p-datatable-scrollable-body'
-      );
-      if (body) {
-        this.scrollContainer = body as HTMLElement;
-        this.scrollContainer.addEventListener('scroll', this.scrollListener);
-        this.captureTopGroup();
-      }
+      this.initGroupScroll();
     }
   }
 
   ngOnDestroy(): void {
-    this.scrollContainer?.removeEventListener('scroll', this.scrollListener);
+    this.destroyGroupScroll();
   }
 
-    trackByFn(index: number, item: any): any {
-      return item.id || index;
-    }
+  trackByFn(index: number, item: any): any {
+    return item.id || index;
+  }
 
-    isRowExpanded(row: any): boolean {
-      const key = row.id || row.key || JSON.stringify(row);
-      return this.expandedRowKeys[key] === true;
-    }
+  isRowExpanded(row: any): boolean {
+    const key = row.id || row.key || JSON.stringify(row);
+    return this.expandedRowKeys[key] === true;
+  }
 
-    isGroupExpanded(groupName: string): boolean {
-      return this.expandedRowKeys[groupName] === true;
-    }
+  isGroupExpanded(groupName: string): boolean {
+    return this.expandedRowKeys[groupName] === true;
+  }
 
-    onGroupToggle(groupName: string): void {
-      const isExpanded = this.isGroupExpanded(groupName);
-      if (isExpanded) {
-        delete this.expandedRowKeys[groupName];
-        this.rowCollapse.emit({ data: groupName });
-      } else {
-        this.expandedRowKeys[groupName] = true;
-        if (this.groupQuery && !this.groupLoaders[groupName]) {
-          this.groupLoaders[groupName] = this.groupQuery(groupName);
-        }
-        this.rowExpand.emit({ data: groupName });
+  onGroupToggle(groupName: string): void {
+    const isExpanded = this.isGroupExpanded(groupName);
+    if (isExpanded) {
+      delete this.expandedRowKeys[groupName];
+      this.rowCollapse.emit({ data: groupName });
+    } else {
+      this.expandedRowKeys[groupName] = true;
+      if (this.groupQuery && !this.groupLoaders[groupName]) {
+        this.groupLoaders[groupName] = this.groupQuery(groupName);
+      }
+      this.rowExpand.emit({ data: groupName });
+    }
+  }
+
+  onRowExpand(event: { originalEvent: Event; data: any }) {
+    console.log('Expanded:', event.data);
+    this.expandedRowKeys[event.data.id] = true;
+    this.rowExpand.emit(event);
+  }
+
+  onRowCollapse(event: any) {
+    delete this.expandedRowKeys[event.data.id];
+    this.rowCollapse.emit(event);
+  }
+
+  filterList(event: any, field: string): void {
+    const selectedValues = event.value.map((item: any) => item.value);
+    if (selectedValues.length === 0) {
+      this.pTable.filter(null, field, 'in');
+    } else {
+      this.pTable.filter(selectedValues, field, 'in');
+    }
+  }
+
+  applySort(event: any): void {
+    if (this.pTable && event) {
+      (this.pTable as any).sortField = event.sortField || event.field;
+      (this.pTable as any).sortOrder = event.sortOrder || event.order;
+      if ((this.pTable as any).sortSingle) {
+        (this.pTable as any).sortSingle();
       }
     }
-
-    onRowExpand(event: { originalEvent: Event, data: any }) {
-      console.log('Expanded:', event.data);
-      this.expandedRowKeys[event.data.id] = true;
-      this.rowExpand.emit(event);
-    }
-  
-    onRowCollapse(event: any) {
-      delete this.expandedRowKeys[event.data.id];
-      this.rowCollapse.emit(event);
-    }    
-
-    filterList(event: any, field: string): void {
-      const selectedValues = event.value.map((item: any) => item.value);
-      if (selectedValues.length === 0) {
-        this.pTable.filter(null, field, 'in');
-      } else {
-        this.pTable.filter(selectedValues, field, 'in');
-      }
-    }
-
-    applySort(event: any): void {
-      if (this.pTable && event) {
-        (this.pTable as any).sortField = event.sortField || event.field;
-        (this.pTable as any).sortOrder = event.sortOrder || event.order;
-        if ((this.pTable as any).sortSingle) {
-          (this.pTable as any).sortSingle();
-        }
-      }
-    }
+  }
 
   applyFilter(event: any): void {
     if (this.pTable && event?.filters && this.mode == 'grid') {
@@ -174,7 +200,7 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy {
 
   onHeaderSort(event: any): void {
     const targetGroup = this.topGroupName;
-    this.detailTables?.forEach(table => table.applySort(event));
+    this.detailTables?.forEach((table) => table.applySort(event));
     setTimeout(() => {
       if (targetGroup) {
         this.scrollToGroup(targetGroup);
@@ -184,7 +210,7 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy {
 
   onHeaderFilter(event: any): void {
     const targetGroup = this.topGroupName;
-    this.detailTables?.forEach(table => table.applyFilter(event));
+    this.detailTables?.forEach((table) => table.applyFilter(event));
     this.pTable.filteredValue = null;
     setTimeout(() => {
       if (targetGroup) {
@@ -198,7 +224,7 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy {
       return;
     }
     const rows = Array.from(
-      this.scrollContainer.querySelectorAll('tbody > tr')
+      this.scrollContainer.querySelectorAll('tbody > tr'),
     );
     for (const row of rows) {
       const el = row as HTMLElement;
@@ -217,7 +243,7 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy {
       return;
     }
     const rows = Array.from(
-      this.scrollContainer.querySelectorAll('tbody > tr')
+      this.scrollContainer.querySelectorAll('tbody > tr'),
     );
     for (const row of rows) {
       const el = row as HTMLElement;
@@ -241,9 +267,25 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy {
       }
     }
 
-    this.detailTables?.forEach(table => {
+    this.detailTables?.forEach((table) => {
       table.columns = [...this.columns];
     });
   }
 
+  private initGroupScroll(): void {
+    const body = (this.pTable?.el?.nativeElement as HTMLElement)?.querySelector(
+      '.p-datatable-scrollable-body',
+    );
+    if (body) {
+      this.destroyGroupScroll();
+      this.scrollContainer = body as HTMLElement;
+      this.scrollContainer.addEventListener('scroll', this.scrollListener);
+      this.captureTopGroup();
+    }
+  }
+
+  private destroyGroupScroll(): void {
+    this.scrollContainer?.removeEventListener('scroll', this.scrollListener);
+    this.scrollContainer = undefined;
+  }
 }


### PR DESCRIPTION
## Summary
- update imports for Angular lifecycle hooks
- reinitialize SuperTable when mode changes
- handle cleanup when mode changes or component is destroyed

## Testing
- `npm test` *(fails: Selector component specs can't build)*
- `npm run prettier:check` *(fails: code style issues in repo)*

------
https://chatgpt.com/codex/tasks/task_e_685f2a8ee5b4832188134e0057b0f6a9