### PR TITLE
Fix expander with filter/sort

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
@@ -11,109 +11,160 @@
   [scrollable]="scrollable"
   [scrollHeight]="scrollHeight"
   [paginator]="paginator"
-  (onSort)="onSort.emit($event)"
-  (onFilter)="onFilter.emit($event)"
+  (onSort)="handleSort($event)"
+  (onFilter)="handleFilter($event)"
   (onColResize)="onColResize.emit($event)"
   expandableRow
   [expandedRowKeys]="expandedRowKeys"
   (onRowExpand)="onRowExpand($event)"
-  (onRowCollapse)="onRowCollapse($event)">
+  (onRowCollapse)="onRowCollapse($event)"
+>
   <ng-template pTemplate="colgroup" let-columns>
     <colgroup>
-      <col *ngFor="let col of columns" [style.width]="col.width">
+      <col *ngFor="let col of columns" [style.width]="col.width" />
     </colgroup>
-  </ng-template>  
+  </ng-template>
   <ng-container *ngIf="showHeader">
     <ng-template pTemplate="header" let-columns>
       <tr class="header-row">
-        <th *ngFor="let col of columns"
-            [pSortableColumn]="col.type === 'string' || col.type === 'date' || col.type === 'boolean' || col.type === 'list' ? col.field : null"
-            pResizableColumn
-            [style.width]="col.width"
-            [style]="col.style">
+        <th
+          *ngFor="let col of columns"
+          [pSortableColumn]="
+            col.type === 'string' ||
+            col.type === 'date' ||
+            col.type === 'boolean' ||
+            col.type === 'list'
+              ? col.field
+              : null
+          "
+          pResizableColumn
+          [style.width]="col.width"
+          [style]="col.style"
+        >
           <div class="p-d-flex p-jc-between p-ai-center">
             {{ col.header }}
             <ng-container [ngSwitch]="col.type">
               <ng-container *ngSwitchCase="'string'">
                 <p-sortIcon [field]="col.field"></p-sortIcon>
-                <p-columnFilter *ngIf="col.filterType" 
-                              [field]="col.field" 
-                              [type]="col.filterType" 
-                              display="menu">
+                <p-columnFilter
+                  *ngIf="col.filterType"
+                  [field]="col.field"
+                  [type]="col.filterType"
+                  display="menu"
+                >
                 </p-columnFilter>
               </ng-container>
               <ng-container *ngSwitchCase="'date'">
                 <p-sortIcon [field]="col.field"></p-sortIcon>
-                <p-columnFilter *ngIf="col.filterType" 
-                              [field]="col.field" 
-                              [type]="col.filterType" 
-                              display="menu">
+                <p-columnFilter
+                  *ngIf="col.filterType"
+                  [field]="col.field"
+                  [type]="col.filterType"
+                  display="menu"
+                >
                 </p-columnFilter>
               </ng-container>
               <ng-container *ngSwitchCase="'boolean'">
                 <p-sortIcon [field]="col.field"></p-sortIcon>
-                <p-columnFilter *ngIf="col.filterType" 
-                              [field]="col.field" 
-                              [type]="col.filterType" 
-                              display="menu">
+                <p-columnFilter
+                  *ngIf="col.filterType"
+                  [field]="col.field"
+                  [type]="col.filterType"
+                  display="menu"
+                >
                 </p-columnFilter>
               </ng-container>
               <ng-container *ngSwitchCase="'list'">
                 <p-sortIcon [field]="col.field"></p-sortIcon>
-                <p-columnFilter [field]="col.field" 
-                              matchMode="in" 
-                              display="menu" 
-                              [showMatchModes]="false" 
-                              [showOperator]="false" 
-                              [showAddButton]="false">
-                  <ng-template pTemplate="filter" let-value let-filter="filterCallback">
-                    <p-multiselect [options]="col.listOptions"
-                                placeholder="Any" 
-                                (onChange)="filterList($event, col.field)" 
-                                optionLabel="label"
-                                [style]="{ 'min-width': '14rem' }" 
-                                [panelStyle]="{ 'min-width': '16rem' }"
-                                [showToggleAll]="true"
-                                [showClear]="true">
+                <p-columnFilter
+                  [field]="col.field"
+                  matchMode="in"
+                  display="menu"
+                  [showMatchModes]="false"
+                  [showOperator]="false"
+                  [showAddButton]="false"
+                >
+                  <ng-template
+                    pTemplate="filter"
+                    let-value
+                    let-filter="filterCallback"
+                  >
+                    <p-multiselect
+                      [options]="col.listOptions"
+                      placeholder="Any"
+                      (onChange)="filterList($event, col.field)"
+                      optionLabel="label"
+                      [style]="{ 'min-width': '14rem' }"
+                      [panelStyle]="{ 'min-width': '16rem' }"
+                      [showToggleAll]="true"
+                      [showClear]="true"
+                    >
                     </p-multiselect>
                   </ng-template>
                 </p-columnFilter>
               </ng-container>
-              <p-tableHeaderCheckbox *ngSwitchCase="'checkbox'"></p-tableHeaderCheckbox>
+              <p-tableHeaderCheckbox
+                *ngSwitchCase="'checkbox'"
+              ></p-tableHeaderCheckbox>
               <span *ngSwitchCase="'expander'"></span>
               <span *ngSwitchCase="'lineNumber'"></span>
             </ng-container>
           </div>
         </th>
       </tr>
-      <tr *ngIf="(dataLoader.loading$ | async)">
-        <td [attr.colspan]="columns.length">{{ dataLoader.loadingMessage$ | async }}</td>
-      </tr> 
+      <tr *ngIf="dataLoader.loading$ | async">
+        <td [attr.colspan]="columns.length">
+          {{ dataLoader.loadingMessage$ | async }}
+        </td>
+      </tr>
     </ng-template>
   </ng-container>
-  <ng-template pTemplate="body" let-rowData let-columns="columns" let-rowIndex="rowIndex">
+  <ng-template
+    pTemplate="body"
+    let-rowData
+    let-columns="columns"
+    let-rowIndex="rowIndex"
+  >
     <tr>
       <td *ngFor="let col of columns">
         <ng-container [ngSwitch]="col.type">
-          <p-tableCheckbox *ngSwitchCase="'checkbox'" [value]="rowData" dataKey="id"></p-tableCheckbox>
+          <p-tableCheckbox
+            *ngSwitchCase="'checkbox'"
+            [value]="rowData"
+            dataKey="id"
+          ></p-tableCheckbox>
           <span *ngSwitchCase="'string'">{{ rowData[col.field] }}</span>
-          <span *ngSwitchCase="'date'">{{ rowData[col.field] | date: (col.dateFormat || 'MM/dd/yyyy') }}</span>
-          <span *ngSwitchCase="'boolean'">{{ rowData[col.field] ? 'Yes' : 'No' }}</span>
+          <span *ngSwitchCase="'date'">{{
+            rowData[col.field] | date: col.dateFormat || 'MM/dd/yyyy'
+          }}</span>
+          <span *ngSwitchCase="'boolean'">{{
+            rowData[col.field] ? 'Yes' : 'No'
+          }}</span>
           <span *ngSwitchCase="'list'">{{ rowData[col.field] }}</span>
           <span *ngSwitchCase="'lineNumber'">{{ rowIndex + 1 }}</span>
-          <button *ngSwitchCase="'expander'"
-                  pButton 
-                  [icon]="isRowExpanded(rowData) ? 'pi pi-chevron-down' : 'pi pi-chevron-right'"
-                  [pRowToggler]="rowData"
-                  class="p-button-text p-button-rounded p-button-plain"
-                  style="width: 2rem; height: 2rem; padding: 0;">
-          </button>
+          <button
+            *ngSwitchCase="'expander'"
+            pButton
+            [icon]="
+              isRowExpanded(rowData)
+                ? 'pi pi-chevron-down'
+                : 'pi pi-chevron-right'
+            "
+            [pRowToggler]="rowData"
+            class="p-button-text p-button-rounded p-button-plain"
+            style="width: 2rem; height: 2rem; padding: 0"
+          ></button>
         </ng-container>
       </td>
     </tr>
   </ng-template>
   <ng-template #expandedrow let-rowData>
-    <ng-container *ngTemplateOutlet="expandedRowTemplate || defaultExpandedRow; context: { $implicit: rowData }"></ng-container>
+    <ng-container
+      *ngTemplateOutlet="
+        expandedRowTemplate || defaultExpandedRow;
+        context: { $implicit: rowData }
+      "
+    ></ng-container>
   </ng-template>
   <ng-template #defaultExpandedRow let-rowData>
     <tr>
@@ -125,107 +176,143 @@
     </tr>
   </ng-template>
 </p-table>
-  <p-table [columns]="columns"
-    *ngIf="mode === 'group'" 
-    #pTable
-    [resizableColumns]="resizableColumns"
-    columnResizeMode="fit"
-    [scrollable]="true" 
-    [scrollHeight]="scrollHeight"    
-    (onSort)="onHeaderSort($event)" 
-    (onFilter)="onHeaderFilter($event)" 
-    (onColResize)="onHeaderColResize($event)"
-    [value]="groups"
-  >
-    <ng-template pTemplate="header" let-columns>
-      <tr class="header-row">
-        <th *ngFor="let col of columns"
-            [pSortableColumn]="col.type === 'string' || col.type === 'date' || col.type === 'boolean' || col.type === 'list' ? col.field : undefined"
-            pResizableColumn
-            [style.width]="col.width"
-            [style]="col.style">
-          <div class="p-d-flex p-jc-between p-ai-center">
-            {{ col.header }}
-            <ng-container [ngSwitch]="col.type">
-              <ng-container *ngSwitchCase="'string'">
-                <p-sortIcon [field]="col.field"></p-sortIcon>
-                <p-columnFilter *ngIf="col.filterType"
-                              [field]="col.field"
-                              [type]="col.filterType"
-                              display="menu">
-                </p-columnFilter>
-              </ng-container>
-              <ng-container *ngSwitchCase="'date'">
-                <p-sortIcon [field]="col.field"></p-sortIcon>
-                <p-columnFilter *ngIf="col.filterType"
-                              [field]="col.field"
-                              [type]="col.filterType"
-                              display="menu">
-                </p-columnFilter>
-              </ng-container>
-              <ng-container *ngSwitchCase="'boolean'">
-                <p-sortIcon [field]="col.field"></p-sortIcon>
-                <p-columnFilter *ngIf="col.filterType"
-                              [field]="col.field"
-                              [type]="col.filterType"
-                              display="menu">
-                </p-columnFilter>
-              </ng-container>
-              <ng-container *ngSwitchCase="'list'">
-                <p-sortIcon [field]="col.field"></p-sortIcon>
-                <p-columnFilter [field]="col.field"
-                              matchMode="in"
-                              display="menu"
-                              [showMatchModes]="false"
-                              [showOperator]="false"
-                              [showAddButton]="false">
-                  <ng-template pTemplate="filter" let-value let-filter="filterCallback">
-                    <p-multiselect [options]="col.listOptions"
-                                placeholder="Any"
-                                (onChange)="filterList($event, col.field)"
-                                optionLabel="label"
-                                [style]="{ 'min-width': '14rem' }"
-                                [panelStyle]="{ 'min-width': '16rem' }"
-                                [showToggleAll]="true"
-                                [showClear]="true">
-                    </p-multiselect>
-                  </ng-template>
-                </p-columnFilter>
-              </ng-container>
-              <p-tableHeaderCheckbox *ngSwitchCase="'checkbox'"></p-tableHeaderCheckbox>
-              <span *ngSwitchCase="'expander'"></span>
-              <span *ngSwitchCase="'lineNumber'"></span>
+<p-table
+  [columns]="columns"
+  *ngIf="mode === 'group'"
+  #pTable
+  [resizableColumns]="resizableColumns"
+  columnResizeMode="fit"
+  [scrollable]="true"
+  [scrollHeight]="scrollHeight"
+  (onSort)="onHeaderSort($event)"
+  (onFilter)="onHeaderFilter($event)"
+  (onColResize)="onHeaderColResize($event)"
+  [value]="groups"
+>
+  <ng-template pTemplate="header" let-columns>
+    <tr class="header-row">
+      <th
+        *ngFor="let col of columns"
+        [pSortableColumn]="
+          col.type === 'string' ||
+          col.type === 'date' ||
+          col.type === 'boolean' ||
+          col.type === 'list'
+            ? col.field
+            : undefined
+        "
+        pResizableColumn
+        [style.width]="col.width"
+        [style]="col.style"
+      >
+        <div class="p-d-flex p-jc-between p-ai-center">
+          {{ col.header }}
+          <ng-container [ngSwitch]="col.type">
+            <ng-container *ngSwitchCase="'string'">
+              <p-sortIcon [field]="col.field"></p-sortIcon>
+              <p-columnFilter
+                *ngIf="col.filterType"
+                [field]="col.field"
+                [type]="col.filterType"
+                display="menu"
+              >
+              </p-columnFilter>
             </ng-container>
-          </div>
-        </th>
-      </tr>
-    </ng-template>
-    <ng-template pTemplate="body" let-rowData>
-      <tr class="p-row-odd">
-        <td style="width: 3rem; text-align: center;">
-          <button type="button" pButton class="p-button-text p-button-rounded p-button-plain"
-                  (click)="onGroupToggle(rowData)">
-            <span [class]="isGroupExpanded(rowData) ? 'pi pi-chevron-down' : 'pi pi-chevron-right'"></span>
-          </button>
-        </td>
-        <td>{{ rowData }}</td>
-      </tr>
-      <tr *ngIf="isGroupExpanded(rowData)">
-        <td [attr.colspan]="columns.length">
-          <super-table
-            #detailTable
-            class="grid-table"
-            [dataLoader]="groupLoaders[rowData]"
-            [columns]="columns"
-            [mode]="'grid'"
-            [superTableParent]="superTableParent"
-            [showHeader]="false"
-            [expandedRowTemplate]="expandedRowTemplate"
-            [resizableColumns]="resizableColumns"
-            [scrollable]="scrollable"
-            [scrollHeight]="scrollHeight"
-          ></super-table>
-        </td>
-      </tr>
-    </ng-template>
-  </p-table>
+            <ng-container *ngSwitchCase="'date'">
+              <p-sortIcon [field]="col.field"></p-sortIcon>
+              <p-columnFilter
+                *ngIf="col.filterType"
+                [field]="col.field"
+                [type]="col.filterType"
+                display="menu"
+              >
+              </p-columnFilter>
+            </ng-container>
+            <ng-container *ngSwitchCase="'boolean'">
+              <p-sortIcon [field]="col.field"></p-sortIcon>
+              <p-columnFilter
+                *ngIf="col.filterType"
+                [field]="col.field"
+                [type]="col.filterType"
+                display="menu"
+              >
+              </p-columnFilter>
+            </ng-container>
+            <ng-container *ngSwitchCase="'list'">
+              <p-sortIcon [field]="col.field"></p-sortIcon>
+              <p-columnFilter
+                [field]="col.field"
+                matchMode="in"
+                display="menu"
+                [showMatchModes]="false"
+                [showOperator]="false"
+                [showAddButton]="false"
+              >
+                <ng-template
+                  pTemplate="filter"
+                  let-value
+                  let-filter="filterCallback"
+                >
+                  <p-multiselect
+                    [options]="col.listOptions"
+                    placeholder="Any"
+                    (onChange)="filterList($event, col.field)"
+                    optionLabel="label"
+                    [style]="{ 'min-width': '14rem' }"
+                    [panelStyle]="{ 'min-width': '16rem' }"
+                    [showToggleAll]="true"
+                    [showClear]="true"
+                  >
+                  </p-multiselect>
+                </ng-template>
+              </p-columnFilter>
+            </ng-container>
+            <p-tableHeaderCheckbox
+              *ngSwitchCase="'checkbox'"
+            ></p-tableHeaderCheckbox>
+            <span *ngSwitchCase="'expander'"></span>
+            <span *ngSwitchCase="'lineNumber'"></span>
+          </ng-container>
+        </div>
+      </th>
+    </tr>
+  </ng-template>
+  <ng-template pTemplate="body" let-rowData>
+    <tr class="p-row-odd">
+      <td style="width: 3rem; text-align: center">
+        <button
+          type="button"
+          pButton
+          class="p-button-text p-button-rounded p-button-plain"
+          (click)="onGroupToggle(rowData)"
+        >
+          <span
+            [class]="
+              isGroupExpanded(rowData)
+                ? 'pi pi-chevron-down'
+                : 'pi pi-chevron-right'
+            "
+          ></span>
+        </button>
+      </td>
+      <td>{{ rowData }}</td>
+    </tr>
+    <tr *ngIf="isGroupExpanded(rowData)">
+      <td [attr.colspan]="columns.length">
+        <super-table
+          #detailTable
+          class="grid-table"
+          [dataLoader]="groupLoaders[rowData]"
+          [columns]="columns"
+          [mode]="'grid'"
+          [superTableParent]="superTableParent"
+          [showHeader]="false"
+          [expandedRowTemplate]="expandedRowTemplate"
+          [resizableColumns]="resizableColumns"
+          [scrollable]="scrollable"
+          [scrollHeight]="scrollHeight"
+        ></super-table>
+      </td>
+    </tr>
+  </ng-template>
+</p-table>

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
@@ -90,6 +90,9 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
 
   groupLoaders: { [key: string]: DataLoader<any> } = {};
 
+  private lastSortEvent: any;
+  private lastFilterEvent: any;
+
   private scrollContainer?: HTMLElement;
   private topGroupName?: string;
   private scrollListener = () => this.captureTopGroup();
@@ -156,6 +159,7 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
         this.groupLoaders[groupName] = this.groupQuery(groupName);
       }
       this.rowExpand.emit({ data: groupName });
+      setTimeout(() => this.applyStoredStateToDetails());
     }
   }
 
@@ -163,6 +167,7 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
     console.log('Expanded:', event.data);
     this.expandedRowKeys[event.data.id] = true;
     this.rowExpand.emit(event);
+    setTimeout(() => this.applyStoredStateToDetails());
   }
 
   onRowCollapse(event: any) {
@@ -177,6 +182,27 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
     } else {
       this.pTable.filter(selectedValues, field, 'in');
     }
+  }
+
+  handleSort(event: any): void {
+    this.lastSortEvent = event;
+    this.onSort.emit(event);
+  }
+
+  handleFilter(event: any): void {
+    this.lastFilterEvent = event;
+    this.onFilter.emit(event);
+  }
+
+  private applyStoredStateToDetails(): void {
+    this.detailTables?.forEach((table) => {
+      if (this.lastSortEvent) {
+        table.applySort(this.lastSortEvent);
+      }
+      if (this.lastFilterEvent) {
+        table.applyFilter(this.lastFilterEvent);
+      }
+    });
   }
 
   applySort(event: any): void {
@@ -200,6 +226,7 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
 
   onHeaderSort(event: any): void {
     const targetGroup = this.topGroupName;
+    this.lastSortEvent = event;
     this.detailTables?.forEach((table) => table.applySort(event));
     setTimeout(() => {
       if (targetGroup) {
@@ -210,6 +237,7 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
 
   onHeaderFilter(event: any): void {
     const targetGroup = this.topGroupName;
+    this.lastFilterEvent = event;
     this.detailTables?.forEach((table) => table.applyFilter(event));
     this.pTable.filteredValue = null;
     setTimeout(() => {


### PR DESCRIPTION
## Summary
- ensure nested tables inherit parent sort/filter
- track current sort and filter events in `SuperTable`
- apply stored sort/filter when expanding rows

## Testing
- `npm test` *(fails: Selector specs)*
- `npx prettier --check src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts`

------
https://chatgpt.com/codex/tasks/task_e_685f4b9877fc8321aab2d48babad7528