### PR TITLE
Propagate column width to child SuperTables

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
@@ -92,6 +92,7 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
 
   private lastSortEvent: any;
   private lastFilterEvent: any;
+  private lastColumnWidths: string[] | undefined;
 
   private scrollContainer?: HTMLElement;
   private topGroupName?: string;
@@ -202,6 +203,9 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
       if (this.lastFilterEvent) {
         table.applyFilter(this.lastFilterEvent);
       }
+      if (this.lastColumnWidths) {
+        table.columns = table.columns.map((c, i) => ({ ...c, width: this.lastColumnWidths![i] }));
+      }
     });
   }
 
@@ -294,6 +298,8 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
         this.columns = [...this.columns];
       }
     }
+
+    this.lastColumnWidths = this.columns.map(col => col.width || '');
 
     this.detailTables?.forEach((table) => {
       table.columns = [...this.columns];


### PR DESCRIPTION
## Summary
- store last header column widths
- apply stored widths when new detail tables are created

## Testing
- `npm test` *(fails: "SelectorUpdateComponent" is marked as standalone and can't be declared in any NgModule)*

------
https://chatgpt.com/codex/tasks/task_e_686012110868832190a428b2faa7a6cc