### PR TITLE
Implement nested group support

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
@@ -36,7 +36,7 @@
       [mode]="viewMode"
       [groups]="groups"
       [groupQuery]="groupQuery.bind(this)"
-      [superTableParent]="this"
+      [superTableParent]="null"
       [resizableColumns]="true"
       [scrollable]="true"
       scrollHeight="flex"

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
@@ -28,6 +28,7 @@ import SharedModule from 'app/shared/shared.module';
 import {
   SuperTable,
   ColumnConfig,
+  GroupDescriptor,
 } from '../../../shared/SuperTable/super-table.component';
 import { DataLoader, FetchFunction } from 'app/shared/data-loader';
 
@@ -59,7 +60,7 @@ export class BirthdayComponent implements OnInit {
   // The SuperTable in group mode manages its own detail tables
 
   dataLoader: DataLoader<IBirthday>;
-  groups: string[] = [];
+  groups: GroupDescriptor[] = [];
   itemsPerPage = 50;
   page = 1;
   predicate!: string;
@@ -214,7 +215,7 @@ export class BirthdayComponent implements OnInit {
         map(response => response.body ?? []),
         map(names => names.sort()),
       )
-      .subscribe(names => (this.groups = names));
+      .subscribe(names => (this.groups = names.map(name => ({ name, count: 0, query: `fname:"${name}"` }))));
   }
 
   ngOnInit(): void {
@@ -372,11 +373,11 @@ export class BirthdayComponent implements OnInit {
     console.log('sort event', event);
   }
 
-  groupQuery(groupName: string): DataLoader<IBirthday> {
+  groupQuery(group: GroupDescriptor): DataLoader<IBirthday> {
     const fetch: FetchFunction<IBirthday> = (queryParams: any) =>
       this.birthdayService.query(queryParams);
     const loader = new DataLoader<IBirthday>(fetch);
-    const filter = { query: `fname:"${groupName}"` };
+    const filter = { query: group.query };
     loader.load(this.itemsPerPage, this.predicate, this.ascending, filter);
     return loader;
   }

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
@@ -24,7 +24,7 @@
       <col *ngFor="let col of columns" [style.width]="col.width" />
     </colgroup>
   </ng-template>
-  <ng-container *ngIf="showHeader">
+  <ng-container *ngIf="showHeader && !superTableParent">
     <ng-template pTemplate="header" let-columns>
       <tr class="header-row">
         <th
@@ -295,17 +295,17 @@
           ></span>
         </button>
       </td>
-      <td>{{ rowData }}</td>
+      <td>{{ rowData.name }}</td>
     </tr>
     <tr *ngIf="isGroupExpanded(rowData)">
       <td [attr.colspan]="columns.length">
         <super-table
           #detailTable
           class="grid-table"
-          [dataLoader]="groupLoaders[rowData]"
+          [dataLoader]="groupLoaders[rowData.name]"
           [columns]="columns"
           [mode]="'grid'"
-          [superTableParent]="superTableParent"
+          [superTableParent]="this"
           [showHeader]="false"
           [expandedRowTemplate]="expandedRowTemplate"
           [resizableColumns]="resizableColumns"


### PR DESCRIPTION
## Summary
- add `GroupDescriptor` interface for nested grouping
- convert groups arrays to `GroupDescriptor[]`
- reference super table parents directly
- show headers only for top-level tables
- adapt birthday component for new structure

## Testing
- `npm run -w src/JhipsterSampleApplication/ClientApp lint`
- `npm run webapp:build`

------
https://chatgpt.com/codex/tasks/task_e_6860afec1a3c832199fa14aff1533799