### PR TITLE
Remove query from group descriptor

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
@@ -215,7 +215,7 @@ export class BirthdayComponent implements OnInit {
         map(response => response.body ?? []),
         map(names => names.sort()),
       )
-      .subscribe(names => (this.groups = names.map(name => ({ name, count: 0, query: `fname:"${name}"` }))));
+      .subscribe(names => (this.groups = names.map(name => ({ name, count: 0, categories: null }))));
   }
 
   ngOnInit(): void {
@@ -377,7 +377,7 @@ export class BirthdayComponent implements OnInit {
     const fetch: FetchFunction<IBirthday> = (queryParams: any) =>
       this.birthdayService.query(queryParams);
     const loader = new DataLoader<IBirthday>(fetch);
-    const filter = { query: group.query };
+    const filter = { query: `fname:"${group.name}"` };
     loader.load(this.itemsPerPage, this.predicate, this.ascending, filter);
     return loader;
   }

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
@@ -49,7 +49,7 @@ export interface ColumnConfig {
 export interface GroupDescriptor {
   name: string;
   count: number;
-  query: string;
+  categories?: string[] | null;
 }
 
 @Component({


### PR DESCRIPTION
## Summary
- drop `query` field from `GroupDescriptor`
- init birthday groups with `categories: null`
- build Lucene query dynamically in `groupQuery`

## Testing
- `npm run lint -w src/JhipsterSampleApplication/ClientApp`
- `npm run webapp:build`


------
https://chatgpt.com/codex/tasks/task_e_6860bfe3c19883219a2d35ce8fd5b67d