### PR TITLE
Implement multi-level supertable view support

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/birthday.model.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/birthday.model.ts
@@ -17,3 +17,8 @@ export class Birthday implements IBirthday {
     public isAlive?: boolean,
   ) {}
 }
+
+export interface IViewResult {
+  categoryName: string;
+  count: number;
+}

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/service/birthday.service.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/service/birthday.service.ts
@@ -5,7 +5,7 @@ import { map } from 'rxjs/operators';
 
 import { ApplicationConfigService } from 'app/core/config/application-config.service';
 import { createRequestOption } from 'app/core/request/request-util';
-import { IBirthday } from '../birthday.model';
+import { IBirthday, IViewResult } from '../birthday.model';
 
 export type EntityResponseType = HttpResponse<IBirthday>;
 export type EntityArrayResponseType = HttpResponse<{
@@ -14,6 +14,14 @@ export type EntityArrayResponseType = HttpResponse<{
   totalHits: number;
   searchAfter: string[];
   pitId: string | null;
+}>;
+
+export type ViewArrayResponseType = HttpResponse<{
+  hits: IViewResult[];
+  hitType: string;
+  viewName: string;
+  viewCategory?: string;
+  totalHits: number;
 }>;
 
 @Injectable({ providedIn: 'root' })
@@ -102,5 +110,28 @@ export class BirthdayService {
         observe: 'response',
       },
     );
+  }
+
+  searchView(req: any): Observable<ViewArrayResponseType> {
+    const options = createRequestOption(req);
+    let queryString = 'query=';
+
+    if (req?.query) {
+      queryString += String(req.query);
+      delete req.query;
+    } else {
+      queryString += '*';
+    }
+
+    return this.http.get<{
+      hits: IViewResult[];
+      hitType: string;
+      viewName: string;
+      viewCategory?: string;
+      totalHits: number;
+    }>(`${this.searchUrl}?${queryString}`, {
+      params: options,
+      observe: 'response',
+    });
   }
 }

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
@@ -302,9 +302,11 @@
         <super-table
           #detailTable
           class="grid-table"
-          [dataLoader]="groupLoaders[rowData.name]"
+          [dataLoader]="groupLoaders[rowData.name]?.loader"
+          [groups]="groupLoaders[rowData.name]?.groups"
+          [mode]="groupLoaders[rowData.name]?.mode || 'grid'"
+          [groupQuery]="groupQuery"
           [columns]="columns"
-          [mode]="'grid'"
           [superTableParent]="this"
           [showHeader]="false"
           [expandedRowTemplate]="expandedRowTemplate"

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
@@ -52,6 +52,12 @@ export interface GroupDescriptor {
   categories?: string[] | null;
 }
 
+export interface GroupData {
+  mode: 'grid' | 'group';
+  loader?: DataLoader<any>;
+  groups?: GroupDescriptor[];
+}
+
 @Component({
   selector: 'super-table',
   standalone: true,
@@ -73,7 +79,9 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
   @Input() columns: ColumnConfig[] = [];
   @Input() groups: GroupDescriptor[] = [];
   @Input() mode: 'grid' | 'group' = 'grid';
-  @Input() groupQuery: ((group: GroupDescriptor) => DataLoader<any>) | undefined;
+  @Input() groupQuery:
+    | ((group: GroupDescriptor) => GroupData)
+    | undefined;
   @Input() loading = false;
   @Input() resizableColumns = false;
   @Input() reorderableColumns = false;
@@ -95,7 +103,7 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
   @ViewChild('pTable') pTable!: Table;
   @ViewChildren('detailTable') detailTables!: QueryList<SuperTable>;
 
-  groupLoaders: { [key: string]: DataLoader<any> } = {};
+  groupLoaders: { [key: string]: GroupData } = {};
 
   private lastSortEvent: any;
   private lastFilterEvent: any;


### PR DESCRIPTION
## Summary
- add `IViewResult` interface to model birthdays API view responses
- expose `searchView` from birthday service for new server API
- update super table to manage group loaders for nested group mode
- load birthday groups using new view API
- support nested grouping logic when expanding groups

## Testing
- `npm run lint`
- `npm test` *(fails: Selector component tests due to standalone declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6860c9752a988321a76969bf1592eae2