### PR TITLE
Fix column alignment and group indentation

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
@@ -297,7 +297,9 @@
           ></span>
         </button>
       </td>
-      <td>{{ rowData.name }}</td>
+      <td [style.padding-left.px]="getGroupIndent(rowData) * 16">
+        {{ rowData.name }}
+      </td>
     </tr>
     <tr *ngIf="isGroupExpanded(rowData)">
       <td [attr.colspan]="columns.length">

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
@@ -171,6 +171,10 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
     return this.expandedRowKeys[group.name] === true;
   }
 
+  getGroupIndent(group: GroupDescriptor): number {
+    return group.categories ? group.categories.length : 0;
+  }
+
   onGroupToggle(group: GroupDescriptor): void {
     const groupName = group.name;
     const isExpanded = this.isGroupExpanded(group);
@@ -183,7 +187,10 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
         this.groupLoaders[groupName] = this.groupQuery(group);
       }
       this.rowExpand.emit({ data: group });
-      setTimeout(() => this.applyStoredStateToDetails());
+      setTimeout(() => {
+        this.captureColumnWidths();
+        this.applyStoredStateToDetails();
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- fix supertable column widths when expanding groups
- indent group rows based on the group category depth

## Testing
- `npm run webapp:build`

------
https://chatgpt.com/codex/tasks/task_e_6861c0a612b48321b4bb120fb0ebf0d2