### PR TITLE
Fix filter application on new supertables

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
@@ -17,6 +17,7 @@ import {
   SimpleChanges,
   ChangeDetectorRef,
 } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { CommonModule } from '@angular/common';
 import { TableModule } from 'primeng/table';
 import { ButtonModule } from 'primeng/button';
@@ -113,6 +114,7 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
   private topGroupName?: string;
   private scrollListener = () => this.captureTopGroup();
   private capturedWidths = false;
+  private detailTablesChangeSub?: Subscription;
 
   @ContentChild('customHeader', { read: TemplateRef })
   headerTemplate?: TemplateRef<any>;
@@ -157,10 +159,14 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
         this.initGroupScroll();
       });
     }
+    this.detailTablesChangeSub = this.detailTables.changes.subscribe(() => {
+      setTimeout(() => this.applyStoredStateToDetails());
+    });
   }
 
   ngOnDestroy(): void {
     this.destroyGroupScroll();
+    this.detailTablesChangeSub?.unsubscribe();
   }
 
   trackByFn(index: number, item: any): any {


### PR DESCRIPTION
## Summary
- apply stored state whenever detail tables are created

## Testing
- `npm run lint -w src/JhipsterSampleApplication/ClientApp`
- `npm run webapp:build`

------
https://chatgpt.com/codex/tasks/task_e_686213b5d6c4832195e4d766a512cc74