### PR TITLE
Add multi-view dropdown and generic grouping

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
@@ -13,6 +13,10 @@
         <span>{{ viewMode === 'grid' ? 'Group View' : 'Grid View' }}</span>
       </button>
 
+      <select class="form-select ms-2 w-auto" [(ngModel)]="viewName" (change)="onViewChange(viewName)">
+        <option *ngFor="let v of views" [ngValue]="v.value">{{ v.label }}</option>
+      </select>
+
       <button
         id="jh-create-entity"
         data-cy="entityCreateButton"


### PR DESCRIPTION
## Summary
- let birthday list choose view
- add generic grouping support using viewName
- expose dropdown for selecting views

## Testing
- `npm test` *(fails: Selector component tests complain about standalone declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6865417705f483219c0ea1fa301ccadf