### PR TITLE
Fix tsconfig paths for popup query builder

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/tsconfig.json
+++ b/src/JhipsterSampleApplication/ClientApp/tsconfig.json
@@ -22,12 +22,12 @@
     "lib": ["es2018", "es2020", "dom"],
     "paths": {
       "ngx-query-builder": [
-        "./dist/ngx-query-builder",
-        "./projects/ngx-query-builder/src/public-api"
+        "../dist/ngx-query-builder",
+        "../projects/ngx-query-builder/src/public-api"
       ],
       "popup-ngx-query-builder": [
-        "./dist/popup-ngx-query-builder",
-        "./projects/popup-ngx-query-builder/src/public-api"
+        "../dist/popup-ngx-query-builder",
+        "../projects/popup-ngx-query-builder/src/public-api"
       ]
     }
   },


### PR DESCRIPTION
## Summary
- fix path mappings in the main tsconfig so popup-ngx-query-builder compiles

## Testing
- `npx ng build ngx-query-builder --configuration development`
- `npx ng build popup-ngx-query-builder --configuration development`

------
https://chatgpt.com/codex/tasks/task_e_687fdf0df1788321ba5699934e43eba4