### PR TITLE
Fix build docs for popup-ngx-query-builder

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/README.md
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/README.md
@@ -24,6 +24,13 @@ To build the library, run:
 ng build popup-ngx-query-builder
 ```
 
+Before running this command, ensure that the `ngx-query-builder` project has been
+built:
+
+```bash
+ng build ngx-query-builder
+```
+
 This command will compile your project, and the build artifacts will be placed in the `dist/` directory.
 
 ### Publishing the Library


### PR DESCRIPTION
## Summary
- clarify that `ngx-query-builder` must be built before `popup-ngx-query-builder`

## Testing
- `npx ng build ngx-query-builder`
- `npx ng build popup-ngx-query-builder`

------
https://chatgpt.com/codex/tasks/task_e_687febaf77948321a5f1cc7dbb261337