### PR TITLE
Fix query builder placeholder and arrow style

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.css
+++ b/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.css
@@ -62,6 +62,8 @@
     transform: rotate(90deg);
     transition: linear 0.25s transform;
     cursor: pointer;
+    text-decoration: none;
+    display: inline-block;
 
     &.q-collapsed {
       transform: rotate(0);
@@ -149,6 +151,7 @@
     visibility: hidden;
     display: inline-block;
     width: 12px;
+    height: 12px;
   }
 
   .q-switch-radio {


### PR DESCRIPTION
## Summary
- tweak query builder CSS for nicer rule placeholder
- prevent underline on collapsed arrows

## Testing
- `npm test -w src/JhipsterSampleApplication/ClientApp/` *(fails: eslint config prettier issues)*

------
https://chatgpt.com/codex/tasks/task_e_6880084ee06c8321a80f220396353721