### PR TITLE
Fix query builder placeholder height

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/eslint.config.js
+++ b/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/eslint.config.js
@@ -1,23 +1,23 @@
 // @ts-check
-const tseslint = require("typescript-eslint");
-const rootConfig = require("../../eslint.config.js");
+const tseslint = require('typescript-eslint');
+const rootConfig = require('../../eslint.config.js');
 
 module.exports = tseslint.config(
   ...rootConfig,
   {
-    files: ["**/*.ts"],
+    files: ['**/*.ts'],
     rules: {
-      "@typescript-eslint/no-explicit-any": "off",
-      "@angular-eslint/directive-selector": "off",
-      "@angular-eslint/component-selector": "off",
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@angular-eslint/directive-selector': 'off',
+      '@angular-eslint/component-selector': 'off',
     },
   },
   {
-    files: ["**/*.html"],
+    files: ['**/*.html'],
     rules: {
-      "@angular-eslint/template/interactive-supports-focus": "off",
-      "@angular-eslint/template/label-has-associated-control": "off",
-      "@angular-eslint/template/click-events-have-key-events": "off",
+      '@angular-eslint/template/interactive-supports-focus': 'off',
+      '@angular-eslint/template/label-has-associated-control': 'off',
+      '@angular-eslint/template/click-events-have-key-events': 'off',
     },
-  }
+  },
 );

--- a/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -127,7 +127,7 @@
                value="and" #andOption />
         <label (click)="changeCondition(andOption.value)" [ngClass]="getClassNames('switchLabel')">
           <ng-container *ngIf="data.rules.length !== 1; else blankAnd">AND</ng-container>
-          <ng-template #blankAnd><span class="q-switch-label-empty">AND</span></ng-template>
+          <ng-template #blankAnd><span class="q-switch-label-empty">&nbsp;</span></ng-template>
         </label>
       </div>
       <div [ngClass]="getClassNames('switchControl')"
@@ -136,7 +136,7 @@
                value="or" #orOption />
         <label (click)="changeCondition(orOption.value)" [ngClass]="getClassNames('switchLabel')">
           <ng-container *ngIf="data.rules.length !== 1; else blankOr">OR</ng-container>
-          <ng-template #blankOr><span class="q-switch-label-empty">OR</span></ng-template>
+          <ng-template #blankOr><span class="q-switch-label-empty">&nbsp;</span></ng-template>
         </label>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- fix placeholder text for query builder switch labels
- run prettier on eslint config

## Testing
- `npm test` *(fails: Selector component tests)*

------
https://chatgpt.com/codex/tasks/task_e_6880178feeb883219cb72dc96a0dfbdc