### PR TITLE
Refine query input UI

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.html
@@ -1,4 +1,4 @@
-<div class="query-input">
+<div class="query-input" [class.editing]="editing">
   <button pButton icon="pi pi-search" class="search-btn" (click)="clickSearch()"></button>
 
   <div class="text" *ngIf="!editing" (click)="startEdit()">
@@ -7,8 +7,8 @@
   <input pInputText *ngIf="editing" [(ngModel)]="query" (ngModelChange)="onQueryChange()" (keyup.enter)="acceptEdit()" [ngClass]="{'invalid': !validQuery}" />
 
   <div class="btn-group" *ngIf="editing">
-    <button pButton icon="pi pi-times" (click)="cancelEdit()"></button>
-    <button pButton icon="pi pi-check" (click)="acceptEdit()" [disabled]="!validQuery"></button>
+    <i class="pi pi-times action-icon" (click)="cancelEdit()"></i>
+    <i class="pi pi-check action-icon" (click)="acceptEdit()" [ngClass]="{'disabled': !validQuery}"></i>
   </div>
 </div>
 

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.scss
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.scss
@@ -24,7 +24,7 @@
 .query-input {
   display: inline-flex;
   align-items: center;
-  font-size: 12px;
+  font-size: 1rem;
   border: none;
   border-radius: 4px;
   padding: 2px 4px;

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.scss
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.scss
@@ -22,12 +22,18 @@
 }
 
 .query-input {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  border: 1px solid #ddd;
+  font-size: 12px;
+  border: none;
   border-radius: 4px;
-  padding: 8px;
-  background: white;
+  padding: 2px 4px;
+  background: transparent;
+
+  &.editing {
+    border: 1px solid #ddd;
+    background: white;
+  }
   
   .search-btn {
     margin-right: 8px;
@@ -57,8 +63,19 @@
   
   .btn-group {
     display: flex;
+    align-items: center;
     gap: 4px;
     margin-left: 8px;
+
+    .action-icon {
+      font-size: 12px;
+      cursor: pointer;
+
+      &.disabled {
+        opacity: 0.5;
+        pointer-events: none;
+      }
+    }
   }
 }
 
@@ -449,50 +466,31 @@
     background: #007bff;
     border: 1px solid #007bff;
     color: white;
-    padding: 8px 12px;
+    padding: 4px 6px;
     border-radius: 4px;
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
-    
+
     &:hover {
       background: #0056b3;
       border-color: #0056b3;
     }
   }
-  
-  .btn-group button {
-    padding: 6px 10px;
-    border-radius: 4px;
-    border: 1px solid #ddd;
-    background: white;
-    cursor: pointer;
+
+  .btn-group {
     display: flex;
     align-items: center;
-    justify-content: center;
-    
-    &:hover {
-      background: #f8f9fa;
-    }
-    
-    &:first-child {
-      border-color: #dc3545;
-      color: #dc3545;
-      
-      &:hover {
-        background: #dc3545;
-        color: white;
-      }
-    }
-    
-    &:last-child {
-      border-color: #28a745;
-      color: #28a745;
-      
-      &:hover {
-        background: #28a745;
-        color: white;
+    gap: 4px;
+
+    .action-icon {
+      font-size: 12px;
+      cursor: pointer;
+
+      &.disabled {
+        opacity: 0.5;
+        pointer-events: none;
       }
     }
   }

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
@@ -1,12 +1,12 @@
 <div style="height: calc(100vh - 174px); display: flex; flex-direction: column;">
-  <h2 id="page-heading" data-cy="BirthdayHeading">
+  <h2 id="page-heading" data-cy="BirthdayHeading" class="d-flex align-items-center gap-2">
     <span>Birthdays...</span>
     <lib-query-input
       [(query)]="currentQuery"
       (queryChange)="onQueryChange($event)"
       placeholder="BQL">
     </lib-query-input>
-    <div class="d-flex justify-content-end">
+    <div class="d-flex ms-auto">
       <button class="btn btn-info me-2" (click)="refreshData()" [disabled]="(dataLoader.loading$ | async)">
         <fa-icon icon="sync" [spin]="(dataLoader.loading$ | async)"></fa-icon>
         <span>Refresh List</span>


### PR DESCRIPTION
## Summary
- tweak birthday header layout
- style query input edit overlay
- use prime icons for edit actions

## Testing
- `npm test -w src/JhipsterSampleApplication/ClientApp/` *(fails: Selector component tests)*

------
https://chatgpt.com/codex/tasks/task_e_688022191db4832197f9cb14ac4de9d6