### PR TITLE
Add clear button and edit restore to query input

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.html
@@ -3,6 +3,7 @@
 
   <div class="text" *ngIf="!editing" (click)="startEdit()">
     <span [ngClass]="{'placeholder': !query}">{{ query || placeholder }}</span>
+    <i class="pi pi-times clear-icon" *ngIf="query" (click)="clearQuery($event)"></i>
   </div>
   <input pInputText *ngIf="editing" [(ngModel)]="query" (ngModelChange)="onQueryChange()" (keyup.enter)="acceptEdit()" [ngClass]="{'invalid': !validQuery}" />
 

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.scss
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.scss
@@ -21,6 +21,7 @@
   height: 100%;
 }
 
+
 .query-input {
   display: inline-flex;
   align-items: center;
@@ -31,6 +32,7 @@
   background: transparent;
 
   &.editing {
+    width: 800px;
     border: 1px solid #ddd;
     background: white;
   }
@@ -44,6 +46,13 @@
     padding: 4px 8px;
     cursor: text;
     min-height: 20px;
+    display: inline-flex;
+    align-items: center;
+
+    .clear-icon {
+      margin-left: 8px;
+      cursor: pointer;
+    }
     
     .placeholder {
       color: #999;

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.ts
@@ -29,7 +29,7 @@ import { EditRulesetDialogComponent } from './edit-ruleset-dialog.component';
   templateUrl: './query-input.component.html'
 })
 export class QueryInputComponent implements OnInit {
-  @Input() placeholder = 'Enter query';
+  @Input() placeholder = 'click search icon for widget or click to edit';
   @Input() query = '';
   @Input() config?: QueryBuilderConfig;
   @Input() allowNot = true;
@@ -44,6 +44,7 @@ export class QueryInputComponent implements OnInit {
   builderQuery: RuleSet = { condition: 'and', rules: [] };
   namedRulesets: Record<string, RuleSet> = {};
   validQuery = true;
+  private previousQuery = '';
 
   constructor(private dialog: MatDialog) {}
 
@@ -52,8 +53,18 @@ export class QueryInputComponent implements OnInit {
   }
 
   startEdit() {
+    this.previousQuery = this.query;
     this.editing = true;
     this.onQueryChange();
+  }
+
+  clearQuery(event?: Event) {
+    if (event) {
+      event.stopPropagation();
+    }
+    this.query = '';
+    this.onQueryChange();
+    this.queryChange.emit(this.query);
   }
 
   onQueryChange() {
@@ -130,10 +141,13 @@ export class QueryInputComponent implements OnInit {
 
   cancelEdit() {
     this.editing = false;
+    this.query = this.previousQuery;
+    this.onQueryChange();
   }
 
   acceptEdit() {
     this.editing = false;
+    this.previousQuery = this.query;
     this.queryChange.emit(this.query);
   }
 


### PR DESCRIPTION
## Summary
- add placeholder that instructs user to click search or edit
- add ability to clear the query
- remember previous query so cancel restores it
- make edit box 800px wide and style clear icon

## Testing
- `npm test` *(fails: "Selector" component tests fail)*
- `DOTNET_USE_POLLING_FILE_WATCHER=1 dotnet test --no-build --logger "console;verbosity=normal"` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68802aec9d588321952b820f9f3903e3