### PR TITLE
Add remove name control for named rulesets

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.css
+++ b/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.css
@@ -363,4 +363,21 @@
   .q-name-modified {
     font-weight: bold;
   }
+
+  .q-name-wrapper {
+    position: relative;
+    display: inline-block;
+  }
+
+  .q-name-remove {
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    border: none;
+    background: none;
+    padding: 0 2px;
+    font-size: 0.65em;
+    cursor: pointer;
+    line-height: 1;
+  }
 }

--- a/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -14,10 +14,13 @@
       </span>
       <span *ngIf="!data.name && config.saveNamedRuleset && !isRulesetInvalid(data) && namingRuleset !== data" class="q-name-text" (click)="startNamingRuleset(data)">Click to name {{rulesetName}}</span>
 
-      <button *ngIf="data.name && config.getNamedRuleset && config.saveNamedRuleset && config.deleteNamedRuleset" type="button" class="q-name-action" (click)="namedRulesetAction(data)" [ngClass]="getClassNames('button')" [class.q-name-action-modified]="namedRulesetModified(data)" [disabled]="disabled" [title]="namedRulesetModified(data) ? rulesetName + ' has been modified needs to be saved, renamed or unnamed' : null">
-        <i [ngClass]="getClassNames(namedRulesetModified(data) ? 'saveIcon' : 'searchIcon')"></i>
-        <span class="q-name-label" [ngClass]="{'q-name-modified': namedRulesetModified(data)}">{{data.name}}</span>
-      </button>
+      <div *ngIf="data.name && config.getNamedRuleset && config.saveNamedRuleset && config.deleteNamedRuleset" class="q-name-wrapper">
+        <button type="button" class="q-name-action" (click)="namedRulesetAction(data)" [ngClass]="getClassNames('button')" [class.q-name-action-modified]="namedRulesetModified(data)" [disabled]="disabled" [title]="namedRulesetModified(data) ? rulesetName + ' has been modified needs to be saved, renamed or unnamed' : null">
+          <i [ngClass]="getClassNames(namedRulesetModified(data) ? 'saveIcon' : 'searchIcon')"></i>
+          <span class="q-name-label" [ngClass]="{'q-name-modified': namedRulesetModified(data)}">{{data.name}}</span>
+        </button>
+        <button type="button" class="q-name-remove" (click)="removeRulesetName(data)" [title]="'Remove ' + rulesetName + ' name'" [disabled]="disabled">✕</button>
+      </div>
 
       <span *ngIf="collapsed && config.customCollapsedSummary" [ngClass]="getClassNames('collapsedSummary')">
         {{ config.customCollapsedSummary(data) }}

--- a/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -1592,4 +1592,22 @@ export class QueryBuilderComponent implements OnChanges, ControlValueAccessor, V
     this.namingRuleset = null;
   }
 
+  removeRulesetName(ruleset: RuleSet = this.data): void {
+    if (!ruleset.name) { return; }
+    const name = ruleset.name;
+    delete ruleset.name;
+    const finalize = () => {
+      this.handleTouched();
+      this.handleDataChange();
+    };
+    if (!this.isRulesetNameInUse(name, this.getRootRuleset(ruleset))) {
+      if (this.config.deleteNamedRuleset) {
+        this.config.deleteNamedRuleset(name);
+      }
+      finalize();
+    } else {
+      finalize();
+    }
+  }
+
 }


### PR DESCRIPTION
## Summary
- add X button for removing a ruleset name in query builder
- style remove-name control
- implement removeRulesetName logic

## Testing
- `npm test` *(fails: Selector component tests)*

------
https://chatgpt.com/codex/tasks/task_e_6881226bd99483219979f5c2302a5690