### PR TITLE
Add clear option to birthday views dropdown

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
@@ -12,10 +12,21 @@
         <span>Refresh List</span>
       </button>
 
-      <select class="form-select ms-2 w-auto" [(ngModel)]="viewName" (ngModelChange)="onViewChange($event)">
-        <option [ngValue]="null">Select a view</option>
-        <option *ngFor="let v of views" [ngValue]="v.value">{{ v.label }}</option>
-      </select>
+      <div class="d-flex align-items-center ms-2">
+        <select class="form-select w-auto" [(ngModel)]="viewName" (ngModelChange)="onViewChange($event)">
+          <option [ngValue]="null">Select a view</option>
+          <option *ngFor="let v of views" [ngValue]="v.value">{{ v.label }}</option>
+        </select>
+        <button
+          *ngIf="viewName"
+          type="button"
+          class="btn btn-link p-0 ms-1"
+          aria-label="Clear selected view"
+          (click)="onViewChange(null)"
+        >
+          <fa-icon icon="times"></fa-icon>
+        </button>
+      </div>
 
       <button
         id="jh-create-entity"


### PR DESCRIPTION
## Summary
- allow unselecting a birthday view via an `x` button

## Testing
- `DOTNET_USE_POLLING_FILE_WATCHER=1 dotnet test --no-build --filter FullyQualifiedName~BirthdaysControllerIntTest --verbosity minimal` *(fails: TestBqlOperations, TestViewOperations, TestCreateAndGetBirthday, TestComplexBqlOperations)*
- `npm test --silent` *(fails: selector component tests)

------
https://chatgpt.com/codex/tasks/task_e_6881523373c883219d9a36b856e2c82d