### PR TITLE
Add tooltips and icon fixes

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
@@ -11,6 +11,7 @@
   [scrollable]="scrollable"
   [scrollHeight]="scrollHeight"
   [paginator]="paginator"
+  [showGridlines]="true"
   (onSort)="handleSort($event)"
   (onFilter)="handleFilter($event)"
   (onColResize)="onColResize.emit($event)"
@@ -133,15 +134,36 @@
             [value]="rowData"
             dataKey="id"
           ></p-tableCheckbox>
-          <span *ngSwitchCase="'string'">{{ rowData[col.field] }}</span>
-          <span *ngSwitchCase="'date'">{{
-            rowData[col.field] | date: col.dateFormat || 'MM/dd/yyyy'
-          }}</span>
-          <span *ngSwitchCase="'boolean'">{{
-            rowData[col.field] ? 'Yes' : 'No'
-          }}</span>
-          <span *ngSwitchCase="'list'">{{ rowData[col.field] }}</span>
-          <span *ngSwitchCase="'lineNumber'">{{ rowIndex + 1 }}</span>
+          <span
+            *ngSwitchCase="'string'"
+            class="cell-content"
+            [pTooltip]="rowData[col.field]"
+            >{{ rowData[col.field] }}</span
+          >
+          <span
+            *ngSwitchCase="'date'"
+            class="cell-content"
+            [pTooltip]="rowData[col.field] | date: col.dateFormat || 'MM/dd/yyyy'"
+            >{{ rowData[col.field] | date: col.dateFormat || 'MM/dd/yyyy' }}</span
+          >
+          <span
+            *ngSwitchCase="'boolean'"
+            class="cell-content"
+            [pTooltip]="rowData[col.field] ? 'Yes' : 'No'"
+            >{{ rowData[col.field] ? 'Yes' : 'No' }}</span
+          >
+          <span
+            *ngSwitchCase="'list'"
+            class="cell-content"
+            [pTooltip]="rowData[col.field]"
+            >{{ rowData[col.field] }}</span
+          >
+          <span
+            *ngSwitchCase="'lineNumber'"
+            class="cell-content"
+            [pTooltip]="rowIndex + 1"
+            >{{ rowIndex + 1 }}</span
+          >
           <button
             *ngSwitchCase="'expander'"
             pButton
@@ -291,6 +313,7 @@
             (click)="onGroupToggle(rowData)"
           >
             <span
+              class="group-toggle-icon"
               [class]="
                 isGroupExpanded(rowData)
                   ? 'pi pi-chevron-down'

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.scss
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.scss
@@ -6,9 +6,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    
+
     .p-button-icon {
-      font-size: 1rem;
+      font-size: 10px;
       color: var(--text-color);
     }
 
@@ -24,5 +24,16 @@
   .group-count {
     margin-left: 0.5rem;
     color: var(--text-color-secondary, #6c757d);
+  }
+
+  .group-toggle-icon {
+    font-size: 10px;
+  }
+
+  .cell-content {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }


### PR DESCRIPTION
## Summary
- show grid lines for basic tables
- add tooltip and ellipsis support for table cells
- standardize expander chevrons

## Testing
- `npm test` *(fails: Selector update component and others)*

------
https://chatgpt.com/codex/tasks/task_e_6881610da0a0832186a206d04156fb3b