### PR TITLE
Adjust table gridlines and header layout

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.scss
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.scss
@@ -4,10 +4,9 @@
     line-height: 22px !important;
   }
   ::ng-deep .p-datatable .p-datatable-tbody > tr > td {
-    padding: 0 !important;
+    padding: 0 0.5rem !important;
     min-height: 22px !important;
     line-height: 22px !important;
-    border-width: 0 !important;
   }
   ::ng-deep .p-datatable .p-datatable-tbody > tr > td > * {
     line-height: 22px !important;
@@ -106,7 +105,7 @@
     max-height: 32px !important;
   }
   ::ng-deep .p-datatable .p-datatable-thead > tr.header-row > th {
-    padding: 0 !important;
+    padding: 0 0.5rem !important;
     height: 32px !important;
     line-height: 32px !important;
     min-height: 32px !important;

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
@@ -42,12 +42,13 @@
           [style.width]="col.width"
           [style]="col.style"
         >
-          <div class="p-d-flex p-jc-between p-ai-center">
-            {{ col.header }}
+          <div class="header-cell">
+            <span class="header-text">{{ col.header }}</span>
             <ng-container [ngSwitch]="col.type">
               <ng-container *ngSwitchCase="'string'">
-                <p-sortIcon [field]="col.field"></p-sortIcon>
+                <p-sortIcon class="sort-icon" [field]="col.field"></p-sortIcon>
                 <p-columnFilter
+                  class="filter-button"
                   *ngIf="col.filterType"
                   [field]="col.field"
                   [type]="col.filterType"
@@ -56,8 +57,9 @@
                 </p-columnFilter>
               </ng-container>
               <ng-container *ngSwitchCase="'date'">
-                <p-sortIcon [field]="col.field"></p-sortIcon>
+                <p-sortIcon class="sort-icon" [field]="col.field"></p-sortIcon>
                 <p-columnFilter
+                  class="filter-button"
                   *ngIf="col.filterType"
                   [field]="col.field"
                   [type]="col.filterType"
@@ -66,8 +68,9 @@
                 </p-columnFilter>
               </ng-container>
               <ng-container *ngSwitchCase="'boolean'">
-                <p-sortIcon [field]="col.field"></p-sortIcon>
+                <p-sortIcon class="sort-icon" [field]="col.field"></p-sortIcon>
                 <p-columnFilter
+                  class="filter-button"
                   *ngIf="col.filterType"
                   [field]="col.field"
                   [type]="col.filterType"
@@ -76,8 +79,9 @@
                 </p-columnFilter>
               </ng-container>
               <ng-container *ngSwitchCase="'list'">
-                <p-sortIcon [field]="col.field"></p-sortIcon>
+                <p-sortIcon class="sort-icon" [field]="col.field"></p-sortIcon>
                 <p-columnFilter
+                  class="filter-button"
                   [field]="col.field"
                   matchMode="in"
                   display="menu"

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
@@ -43,7 +43,7 @@
           [style]="col.style"
         >
           <div class="header-cell">
-            <span class="header-text">{{ col.header }}</span>
+            <span *ngIf="col.filterType" class="header-text">{{ col.header }}</span>
             <ng-container [ngSwitch]="col.type">
               <ng-container *ngSwitchCase="'string'">
                 <p-sortIcon class="sort-icon" [field]="col.field"></p-sortIcon>
@@ -147,7 +147,7 @@
           <span
             *ngSwitchCase="'date'"
             class="cell-content"
-            [pTooltip]="rowData[col.field] | date: col.dateFormat || 'MM/dd/yyyy'"
+            [pTooltip]="(rowData[col.field] | date: col.dateFormat || 'MM/dd/yyyy') || ''"
             >{{ rowData[col.field] | date: col.dateFormat || 'MM/dd/yyyy' }}</span
           >
           <span

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.scss
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.scss
@@ -39,7 +39,6 @@
 
   .header-cell {
     position: relative;
-    padding: 0 0.5rem;
     min-height: 32px;
   }
 

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.scss
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.scss
@@ -36,4 +36,35 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+
+  .header-cell {
+    position: relative;
+    padding: 0 0.5rem;
+    min-height: 32px;
+  }
+
+  .header-text {
+    padding-right: 0.5rem;
+  }
+
+  .sort-icon {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+
+    .p-sortable-column-icon {
+      font-size: 10px;
+    }
+  }
+
+  .filter-button {
+    position: absolute;
+    right: 0;
+
+    .p-column-filter-menu-button {
+      width: 1rem;
+      height: 1rem;
+      font-size: 10px;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add flex-based header cell structure with smaller icons
- style header cell layout and icon sizes
- show gridlines in entity rows and pad header cells

## Testing
- `npm test --silent` *(fails: Selector component specs)*
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6881688451dc8321976a26b4813d66e1