### PR TITLE
Update DataLoader message logic

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/data-loader.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/data-loader.ts
@@ -117,9 +117,16 @@ export class DataLoader<T> {
     const totalItems = this.totalItemsSubject.getValue();
 
     if (currentLength >= this.dataLoadLimit) {
-      const message = `${totalItems} hits (too many to display, showing the first ${this.dataLoadLimit})`;
-      this.loadingMessageSubject.next(message);
-      this.loadingSubject.next(false);
+      if (totalItems > this.dataLoadLimit) {
+        const hitLabel =
+          totalItems >= 10000 ? 'Over 10000' : totalItems.toString();
+        const message = `${hitLabel} hits (too many to display, showing the first ${this.dataLoadLimit})`;
+        this.loadingMessageSubject.next(message);
+        this.loadingSubject.next(true);
+      } else {
+        this.loadingMessageSubject.next('');
+        this.loadingSubject.next(false);
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- keep the loading row visible when total hits exceed the display limit
- show `Over 10000 hits` message for very large result sets

## Testing
- `npm test --silent` *(fails: SelectorUpdateComponent standalone issue)*

------
https://chatgpt.com/codex/tasks/task_e_68821e36dba08321b5487a8896c209ef