### PR TITLE
Fix super-table gridlines with groups

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
@@ -117,7 +117,7 @@
           </div>
         </th>
       </tr>
-      <tr *ngIf="dataLoader.loading$ | async">
+      <tr *ngIf="dataLoader.loading$ | async" class="loading-row">
         <td [attr.colspan]="columns.length">
           {{ dataLoader.loadingMessage$ | async }}
         </td>
@@ -210,6 +210,7 @@
   columnResizeMode="fit"
   [scrollable]="true"
   [scrollHeight]="scrollHeight"
+  [showGridlines]="false"
   (onSort)="onHeaderSort($event)"
   (onFilter)="onHeaderFilter($event)"
   (onColResize)="onHeaderColResize($event)"

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.scss
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.scss
@@ -67,3 +67,8 @@
     }
   }
 }
+
+:host ::ng-deep .loading-row td {
+  border-bottom: 1px solid var(--surface-border, #dee2e6);
+}
+


### PR DESCRIPTION
## Summary
- don't show gridlines when using groups
- add bottom gridline to loading row

## Testing
- `npm test` *(fails: Selector components can't be declared in TestBed)*

------
https://chatgpt.com/codex/tasks/task_e_6882235327188321b029f74126ceca95