### PR TITLE
Center checkboxes in SuperTable cells

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.scss
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.scss
@@ -75,3 +75,11 @@
   padding-left: 4px;
 }
 
+/* Center checkboxes in table cells */
+:host ::ng-deep td > p-tablecheckbox,
+:host ::ng-deep td > p-tableHeaderCheckbox {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+


### PR DESCRIPTION
## Summary
- center p-table checkboxes in table cells

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688241e6bc888321a7b2300c0caca958