### PR TITLE
Fix query builder expander CSS and empty query handling

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.css
+++ b/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.css
@@ -62,9 +62,12 @@
     transform: rotate(90deg);
     transition: linear 0.25s transform;
     cursor: pointer;
+    border-bottom: 1px solid #ccc;
 
     &.q-collapsed {
       transform: rotate(0);
+      border-bottom: 0;
+      border-left: 1px solid #ccc;
     }
   }
 

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.html
@@ -33,7 +33,8 @@
     [allowConvertToRuleset]="allowConvertToRuleset"
     [allowRuleUpDown]="allowRuleUpDown"
     [ruleName]="ruleName"
-    [rulesetName]="rulesetName"></ngx-query-builder>
+    [rulesetName]="rulesetName"
+    [defaultRuleAttribute]="defaultRuleAttribute"></ngx-query-builder>
   
   <ng-template pTemplate="footer">
     <div class="dialog-footer">

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.ts
@@ -47,6 +47,7 @@ export class QueryInputComponent implements OnInit {
   @Input() allowRuleUpDown = true;
   @Input() ruleName = 'Rule';
   @Input() rulesetName = 'Ruleset';
+  @Input() defaultRuleAttribute: string | null = null;
   @Output() queryChange = new EventEmitter<string>();
 
   editing = false;
@@ -184,8 +185,16 @@ export class QueryInputComponent implements OnInit {
   }
 
   parseQuery(text: string): RuleSet {
+    const trimmed = text.trim();
+    if (!trimmed) {
+      const fields = Object.keys(this.queryBuilderConfig.fields);
+      const attr = this.defaultRuleAttribute || fields[0];
+      const rule = attr ? ({ field: attr } as Rule) : undefined;
+      return { condition: 'and', rules: rule ? [rule] : [] };
+    }
+
     try {
-      return bqlToRuleset(text, this.queryBuilderConfig);
+      return bqlToRuleset(trimmed, this.queryBuilderConfig);
     } catch {
       return { condition: 'and', rules: [] };
     }


### PR DESCRIPTION
## Summary
- correct query builder expander borders
- allow QueryInputComponent to pass a default rule attribute
- when BQL text is empty initialize with single rule

## Testing
- `npm test` *(fails: Selector component tests and others)*

------
https://chatgpt.com/codex/tasks/task_e_68824b6b62c483218a7a874e1af2c33c