### PR TITLE
Fix view refresh after BQL query changes

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
@@ -153,6 +153,11 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
         this.destroyGroupScroll();
       }
     }
+    if (changes['groups'] && !changes['groups'].firstChange) {
+      // Clear cached group data and expanded state when groups change
+      this.groupLoaders = {};
+      this.expandedRowKeys = {};
+    }
   }
 
   ngAfterViewInit(): void {

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/data-loader.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/data-loader.ts
@@ -56,6 +56,9 @@ export class DataLoader<T> {
     this.ascending = ascending;
     this.filter = filter;
     this.buffer = []; // Reset buffer on new load
+    // Reset pagination state to ensure a fresh search
+    this.pitId = null;
+    this.searchAfter = [];
 
     const queryParams: any = {
       pageSize: this.itemsPerPage,


### PR DESCRIPTION
## Summary
- clear DataLoader paging state between loads
- reset group caches in SuperTable when groups change

## Testing
- `npm test --silent` *(fails: Selector components)*
- `dotnet test --no-build --logger "console;verbosity=normal"` *(partial output, .NET info)*

------
https://chatgpt.com/codex/tasks/task_e_6883e838a8888321a1f4f08e73e46cf4