### PR TITLE
Fix expander column width in nested grids

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
@@ -320,21 +320,26 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
       return;
     }
 
-    this.detailTables.forEach((table, index) => {
+    this.detailTables.forEach(table => {
       if (table.columns && headerWidths) {
         const minLength = Math.min(table.columns.length, headerWidths.length);
-        
-        // Apply header widths to all columns
+
+        const appliedWidths: string[] = [];
+
         table.columns = table.columns.map((col, i) => {
           if (i < minLength) {
-            return { ...col, width: headerWidths[i] };
+            const parentCol = this.columns[i];
+            const width = parentCol?.width || headerWidths[i];
+            appliedWidths.push(width);
+            return { ...col, width };
           }
-          return { ...col }; // Keep original width for out-of-range columns
+          appliedWidths.push(col.width ?? '');
+          return { ...col };
         });
 
         // Force DOM update with header widths
         setTimeout(() => {
-          table.forceColumnUpdate(headerWidths);
+          table.forceColumnUpdate(appliedWidths);
         }, 10);
       }
     });


### PR DESCRIPTION
## Summary
- keep custom column widths when syncing group/detail tables

## Testing
- `npm test -w src/JhipsterSampleApplication/ClientApp/` *(fails: Selector tests)*

------
https://chatgpt.com/codex/tasks/task_e_68843fcffb7883219c27715c4d485c01