### PR TITLE
Add column width persistence

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/job/list/job.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/job/list/job.component.html
@@ -30,7 +30,7 @@
     </div>
   } @else {
     <div class="table-responsive table-entities" id="entities">
-      <table class="table table-striped" aria-describedby="page-heading">
+      <table class="table table-striped" aria-describedby="page-heading" jhiPersistColumnWidths="jobList">
         <thead>
           <tr jhiSort [(sortState)]="sortState" (sortChange)="navigateToWithComponentValues($event)">
             <th scope="col" jhiSortBy="id">

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/column-width/column-width.directive.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/column-width/column-width.directive.ts
@@ -1,0 +1,36 @@
+import { Directive, ElementRef, Input, AfterViewInit, OnDestroy } from '@angular/core';
+
+@Directive({
+  selector: '[jhiPersistColumnWidths]',
+})
+export class ColumnWidthDirective implements AfterViewInit, OnDestroy {
+  @Input('jhiPersistColumnWidths') key = '';
+
+  constructor(private el: ElementRef<HTMLTableElement>) {}
+
+  ngAfterViewInit(): void {
+    if (!this.key) return;
+    const stored = localStorage.getItem(`column-widths:${this.key}`);
+    if (stored) {
+      try {
+        const widths = JSON.parse(stored) as number[];
+        const ths = this.el.nativeElement.querySelectorAll('th');
+        ths.forEach((th, i) => {
+          const width = widths[i];
+          if (width) {
+            (th as HTMLElement).style.width = `${width}px`;
+          }
+        });
+      } catch {
+        // ignore parse errors
+      }
+    }
+  }
+
+  ngOnDestroy(): void {
+    if (!this.key) return;
+    const ths = this.el.nativeElement.querySelectorAll('th');
+    const widths = Array.from(ths).map(th => (th as HTMLElement).offsetWidth);
+    localStorage.setItem(`column-widths:${this.key}`, JSON.stringify(widths));
+  }
+}

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/column-width/index.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/column-width/index.ts
@@ -1,0 +1,1 @@
+export * from './column-width.directive';

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/index.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/index.ts
@@ -1,0 +1,4 @@
+export * from './column-width';
+export * from './sort';
+export * from './alert/alert.component';
+export * from './alert/alert-error.component';

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/shared.module.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/shared.module.ts
@@ -4,12 +4,13 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { AlertComponent } from './alert/alert.component';
 import { AlertErrorComponent } from './alert/alert-error.component';
+import { ColumnWidthDirective } from './column-width/column-width.directive';
 
 /**
  * Application wide Module
  */
 @NgModule({
-  imports: [AlertComponent, AlertErrorComponent],
-  exports: [CommonModule, NgbModule, FontAwesomeModule, AlertComponent, AlertErrorComponent],
+  imports: [AlertComponent, AlertErrorComponent, ColumnWidthDirective],
+  exports: [CommonModule, NgbModule, FontAwesomeModule, AlertComponent, AlertErrorComponent, ColumnWidthDirective],
 })
 export default class SharedModule {}


### PR DESCRIPTION
## Summary
- persist column widths across navigation using a new directive
- export the directive via SharedModule
- demonstrate usage in job list table

## Testing
- `npm --prefix src/JhipsterSampleApplication/ClientApp test --silent`
- `dotnet test` *(fails: Installed an ASP.NET Core HTTPS development certificate, then various tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_688448569ec88321ae14008b6756d327