### PR TITLE
Fix grid alignment and loader message

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.scss
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.scss
@@ -77,7 +77,7 @@
     min-height: 16px !important;
     max-height: 16px !important;
     position: relative !important;
-    top: -3px !important;
+    top: 0 !important;
   }
   ::ng-deep .p-checkbox .p-checkbox-box {
     width: 16px !important;

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
@@ -352,10 +352,13 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
       }
     });
     
-    // Force reset loading state if stuck  
+    // Force reset loading state if stuck
     setTimeout(() => {
-      this.dataLoader.loading$.subscribe(loading => {
-        if (loading) {
+      combineLatest([
+        this.dataLoader.loading$,
+        this.dataLoader.loadingMessage$,
+      ]).subscribe(([loading, message]) => {
+        if (loading && (!message || message.toLowerCase().startsWith('loading'))) {
           this.forceResetLoading();
         }
       });

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
@@ -46,7 +46,7 @@
           [style]="col.style"
         >
           <div class="header-cell">
-            <span *ngIf="col.filterType" class="header-text">{{ col.header }}</span>
+            <span class="header-text">{{ col.header }}</span>
             <ng-container [ngSwitch]="col.type">
               <ng-container *ngSwitchCase="'string'">
                 <p-sortIcon class="sort-icon" [field]="col.field"></p-sortIcon>

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.scss
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.scss
@@ -129,5 +129,6 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- center grid checkboxes
- preserve loading message when rows exceed the limit
- always show column header text in grid view
- adjust zodiac checkbox style

## Testing
- `dotnet test --no-build --verbosity normal`
- `npm test` *(fails: Selector tests)*

------
https://chatgpt.com/codex/tasks/task_e_68867084c4cc8321b86237748f7ce660