### PR TITLE
Fix header text and preserve state in group mode

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
@@ -95,6 +95,7 @@
       (onContextMenuSelect)="setMenu($event.data)"
       (contextMenuSelectionChange)="onContextMenuSelect($event)"
       (onSort)="onSort($event)"
+      (onFilter)="onFilter($event)"
       [expandedRowTemplate]="expandedRow"
     ></super-table>
   </div>

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
@@ -223,6 +223,7 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
   chipSelectedRows: IBirthday[] = [];
 
   private lastSortEvent: any = null;
+  private lastFilterEvent: any = null;
   private lastExpandedGroups: string[] = [];
 
   bDisplaySearchDialog = false;
@@ -398,6 +399,10 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
     this.lastSortEvent = event;
   }
 
+  onFilter(event: any): void {
+    this.lastFilterEvent = event;
+  }
+
   refreshData(): void {
     console.log('refreshData called');
     
@@ -413,6 +418,9 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
         this.loadPage();
         if (this.lastSortEvent) {
           setTimeout(() => this.superTable.applySort(this.lastSortEvent));
+        }
+        if (this.lastFilterEvent) {
+          setTimeout(() => this.superTable.applyFilter(this.lastFilterEvent));
         }
       }
     } catch (error) {
@@ -515,6 +523,9 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
     }
     if (this.lastSortEvent) {
       this.superTable.applySort(this.lastSortEvent);
+    }
+    if (this.lastFilterEvent) {
+      this.superTable.applyFilter(this.lastFilterEvent);
     }
   }
 

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.html
@@ -46,7 +46,7 @@
           [style]="col.style"
         >
           <div class="header-cell">
-            <span *ngIf="col.filterType" class="header-text">{{ col.header }}</span>
+            <span class="header-text">{{ col.header }}</span>
             <ng-container [ngSwitch]="col.type">
               <ng-container *ngSwitchCase="'string'">
                 <p-sortIcon class="sort-icon" [field]="col.field"></p-sortIcon>

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
@@ -274,6 +274,7 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
     const targetGroup = this.topGroupName;
     this.lastSortEvent = event;
     this.detailTables?.forEach(table => table.applySort(event));
+    this.onSort.emit(event);
     requestAnimationFrame(() => {
       if (targetGroup) {
         this.scrollToGroup(targetGroup);
@@ -286,6 +287,7 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
     this.lastFilterEvent = event;
     this.detailTables?.forEach(table => table.applyFilter(event));
     this.pTable.filteredValue = null;
+    this.onFilter.emit(event);
     setTimeout(() => {
       if (targetGroup) {
         this.scrollToGroup(targetGroup);


### PR DESCRIPTION
## Summary
- show column header text regardless of filter type
- emit sort and filter events from group header
- track filter events in BirthdayComponent
- restore sort and filters when refreshing

## Testing
- `npm test` *(fails: Selector specs fail due to standalone component declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6887670f8788832191f0935e9393b706