### PR TITLE
Fix sort/filter persistence in SuperTable

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
@@ -285,16 +285,27 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
       this.lastColumnWidths = currentWidths;
     }
 
-    this.detailTables?.forEach(table => {
-      table.columns = [...this.columns];
-      if (this.lastSortEvent) {
-        table.applySort(this.lastSortEvent);
-      }
-      if (this.lastFilterEvent) {
-        table.applyFilter(this.lastFilterEvent);
-      }
-    });
+    const tables = this.detailTables?.toArray() ?? [];
+    if (tables.length === 0) {
+      // Child tables might not yet exist when a group is first expanded.
+      // Retry after change detection so the sort and filters can be applied.
+      setTimeout(() => this.applyStoredStateToDetails());
+      return;
+    }
 
+    tables.forEach(table => this.applyStateToChild(table));
+
+  }
+
+  private applyStateToChild(table: SuperTable): void {
+    table.columns = [...this.columns];
+    if (this.lastSortEvent) {
+      table.applySort(this.lastSortEvent);
+    }
+    if (this.lastFilterEvent) {
+      table.applyFilter(this.lastFilterEvent);
+    }
+    table.cdr.detectChanges();
   }
 
   applySort(event: any): void {


### PR DESCRIPTION
## Summary
- handle asynchronous creation of group detail tables
- defer applying column sort and filters until nested tables exist

## Testing
- `npm test` *(fails: 5 failed, 41 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68877129ce2483219abb4b0689b7309c