### PR TITLE
Fix header state persistence in SuperTable

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
@@ -233,6 +233,18 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
   showRowNumbers = false;
   private loadingSubscription?: Subscription;
 
+  private syncSortFilterFromHeader(): void {
+    if (this.superTable) {
+      this.superTable.captureHeaderState();
+      const sortEvent: any = (this.superTable as any).sortEvent;
+      if (sortEvent) {
+        this.predicate = sortEvent.field || sortEvent.sortField || this.predicate;
+        this.ascending = (sortEvent.order ?? sortEvent.sortOrder) === 1;
+      }
+      this.lastSortEvent = sortEvent;
+    }
+  }
+
   constructor(
     protected birthdayService: BirthdayService,
     protected activatedRoute: ActivatedRoute,
@@ -255,9 +267,7 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
   }
 
   loadRootGroups(restoreState: boolean = false): void {
-    if (this.superTable) {
-      this.superTable.captureHeaderState();
-    }
+    this.syncSortFilterFromHeader();
     if (!this.viewName) {
       this.groups = [];
       this.loadPage();
@@ -405,9 +415,7 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
     console.log('refreshData called');
     
     try {
-      if (this.superTable) {
-        this.superTable.captureHeaderState();
-      }
+      this.syncSortFilterFromHeader();
       if (this.viewMode === 'group') {
         this.lastExpandedGroups = Object.keys(
           this.superTable.expandedRowKeys,
@@ -582,9 +590,7 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
   }
 
   loadPage(): void {
-    if (this.superTable) {
-      this.superTable.captureHeaderState();
-    }
+    this.syncSortFilterFromHeader();
     const filter: any = {};
     if (this.currentQuery && this.currentQuery.trim().length > 0) {
       filter.bqlQuery = this.currentQuery.trim();
@@ -647,6 +653,7 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
   }
 
   groupQuery(group: GroupDescriptor): GroupData {
+    this.syncSortFilterFromHeader();
     const path = group.categories
       ? [...group.categories, group.name]
       : [group.name];

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/SuperTable/super-table.component.ts
@@ -116,6 +116,14 @@ export class SuperTable implements OnInit, AfterViewInit, OnDestroy, OnChanges {
   private scrollListener = () => this.captureTopGroup();
   private capturedWidths = false;
 
+  get sortEvent(): any {
+    return this.lastSortEvent;
+  }
+
+  get filterEvent(): any {
+    return this.lastFilterEvent;
+  }
+
   get visibleColumns(): ColumnConfig[] {
     return this.showRowNumbers ? this.columns : this.columns.filter(c => c.type !== 'lineNumber');
   }


### PR DESCRIPTION
## Summary
- expose current sort/filter info from `SuperTable`
- sync sort and filter when loading pages, groups or refreshing

## Testing
- `npm test --silent` *(fails: Selector component tests)*

------
https://chatgpt.com/codex/tasks/task_e_6887802ad280832191f20b76bbc35bfc