### PR TITLE
Fix table details after refresh

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
@@ -425,7 +425,10 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
         this.loadRootGroups(true);
       } else {
         this.loadPage();
-        setTimeout(() => this.superTable.applyCapturedHeaderState());
+        setTimeout(() => {
+          this.superTable.applyCapturedHeaderState();
+          (this.superTable as any).applyStoredStateToDetails();
+        });
       }
     } catch (error) {
       console.error('Error in refreshData:', error);
@@ -466,6 +469,10 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
       this.groups = [];
       this.viewMode = 'grid';
       this.loadPage();
+      setTimeout(() => {
+        this.superTable.applyCapturedHeaderState();
+        (this.superTable as any).applyStoredStateToDetails();
+      });
     }
   }
 
@@ -526,6 +533,7 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
       }
     }
     this.superTable.applyCapturedHeaderState();
+    setTimeout(() => (this.superTable as any).applyStoredStateToDetails());
   }
 
   showMenu(event: MouseEvent): void {


### PR DESCRIPTION
## Summary
- set up timers to reapply stored column details after refresh and view change
- update restoreState to keep detail tables synchronized

## Testing
- `npm test` *(fails: Selector component tests)*

------
https://chatgpt.com/codex/tasks/task_e_68878710a1d48321907ce40ef2aa9442