### PR TITLE
Fix column state persistence when toggling views

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
@@ -294,6 +294,8 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
             this.viewMode = 'group';
             if (restoreState) {
               setTimeout(() => this.restoreState());
+            } else {
+              setTimeout(() => this.superTable.applyCapturedHeaderState());
             }
           } else {
             this.groups = [];
@@ -306,9 +308,7 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
               filter,
             );
             this.viewMode = 'grid';
-            if (restoreState) {
-              setTimeout(() => this.superTable.applyCapturedHeaderState());
-            }
+            setTimeout(() => this.superTable.applyCapturedHeaderState());
           }
         });
     } else {
@@ -325,6 +325,8 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
             this.viewMode = 'group';
             if (restoreState) {
               setTimeout(() => this.restoreState());
+            } else {
+              setTimeout(() => this.superTable.applyCapturedHeaderState());
             }
           } else {
             this.groups = [];
@@ -336,9 +338,7 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
               filter,
             );
             this.viewMode = 'grid';
-            if (restoreState) {
-              setTimeout(() => this.superTable.applyCapturedHeaderState());
-            }
+            setTimeout(() => this.superTable.applyCapturedHeaderState());
           }
         });
     }


### PR DESCRIPTION
## Summary
- ensure column widths/filters/sort apply when switching between grid and group modes

## Testing
- `npm test` *(fails: Selector components tests)*

------
https://chatgpt.com/codex/tasks/task_e_68879c899b688321aa641ae0e197033f