### PR TITLE
feat: add default rule when setting condition

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -125,20 +125,20 @@
         </label>
       </div>
       <div [ngClass]="getClassNames('switchControl')"
-           *ngIf="data.condition === 'and' || (hoveringSwitchGroup && data.rules.length !== 1)">
+           *ngIf="data.condition === 'and' || hoveringSwitchGroup">
         <input type="radio" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.condition" [disabled]=disabled
                value="and" #andOption />
         <label (click)="changeCondition(andOption.value)" [ngClass]="getClassNames('switchLabel')">
-          <ng-container *ngIf="data.rules.length !== 1; else blankAnd">AND</ng-container>
+          <ng-container *ngIf="hoveringSwitchGroup || data.rules.length !== 1; else blankAnd">AND</ng-container>
           <ng-template #blankAnd><span class="q-switch-label-empty">&nbsp;</span></ng-template>
         </label>
       </div>
       <div [ngClass]="getClassNames('switchControl')"
-           *ngIf="data.condition === 'or' || (hoveringSwitchGroup && data.rules.length !== 1)">
+           *ngIf="data.condition === 'or' || hoveringSwitchGroup">
         <input type="radio" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.condition" [disabled]=disabled
                value="or" #orOption />
         <label (click)="changeCondition(orOption.value)" [ngClass]="getClassNames('switchLabel')">
-          <ng-container *ngIf="data.rules.length !== 1; else blankOr">OR</ng-container>
+          <ng-container *ngIf="hoveringSwitchGroup || data.rules.length !== 1; else blankOr">OR</ng-container>
           <ng-template #blankOr><span class="q-switch-label-empty">&nbsp;</span></ng-template>
         </label>
       </div>

--- a/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.spec.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.spec.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatDialogModule } from '@angular/material/dialog';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { SimpleChange } from '@angular/core';
 import { QueryBuilderComponent } from './query-builder.component';
 import { RuleSet } from '../models/query-builder.interfaces';
 import { AddNamedRulesetDialogComponent } from './add-named-ruleset-dialog.component';
@@ -13,18 +14,22 @@ describe('QueryBuilderComponent', () => {
   let component: QueryBuilderComponent;
   let fixture: ComponentFixture<QueryBuilderComponent>;
 
-  beforeEach((() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ CommonModule, FormsModule, MatDialogModule, BrowserAnimationsModule ],
+      imports: [
+        CommonModule,
+        FormsModule,
+        MatDialogModule,
+        BrowserAnimationsModule,
+      ],
       declarations: [
         QueryBuilderComponent,
         AddNamedRulesetDialogComponent,
         NamedRulesetDialogComponent,
-        MessageDialogComponent
-      ]
-    })
-    .compileComponents();
-  }));
+        MessageDialogComponent,
+      ],
+    }).compileComponents();
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(QueryBuilderComponent);
@@ -39,19 +44,45 @@ describe('QueryBuilderComponent', () => {
   it('should save unstored named rulesets when value is set', () => {
     const save = jasmine.createSpy('save');
     const list = jasmine.createSpy('list').and.returnValue([]);
-    component.config = { fields: {}, saveNamedRuleset: save, listNamedRulesets: list } as any;
+    component.config = {
+      fields: {},
+      saveNamedRuleset: save,
+      listNamedRulesets: list,
+    } as any;
     const query: RuleSet = {
       condition: 'and',
       rules: [
         { field: 'a', operator: '=' },
-        { condition: 'and', rules: [{ field: 'b', operator: '=' }], name: 'INNER' }
+        {
+          condition: 'and',
+          rules: [{ field: 'b', operator: '=' }],
+          name: 'INNER',
+        },
       ],
-      name: 'ROOT'
+      name: 'ROOT',
     };
     component.value = query;
     expect(save.calls.count()).toBe(2);
-    const names = save.calls.allArgs().map(a => a[0].name);
+    const names = save.calls.allArgs().map((a) => a[0].name);
     expect(names).toContain('ROOT');
     expect(names).toContain('INNER');
+  });
+
+  it('should add a rule when selecting a condition on a single-rule set', () => {
+    component.operatorMap = { string: ['='] } as any;
+    component.config = {
+      fields: { name: { name: 'Name', type: 'string', operators: ['='] } },
+    } as any;
+    component.defaultRuleAttribute = 'name';
+    component.data = { condition: 'and', rules: [] } as RuleSet;
+    component.ngOnChanges({
+      config: new SimpleChange(null, component.config, true),
+    } as any);
+    component.addRule();
+    expect(component.data.rules.length).toBe(1);
+    component.changeCondition('or');
+    expect(component.data.condition).toBe('or');
+    expect(component.data.rules.length).toBe(2);
+    expect((component.data.rules[1] as any).field).toBe('name');
   });
 });

--- a/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -760,10 +760,15 @@ export class QueryBuilderComponent
     if (this.disabled) {
       return;
     }
+    const wasSingleRule = this.data.rules && this.data.rules.length === 1;
 
     this.data.condition = value;
     this.handleTouched();
     this.handleDataChange();
+
+    if (wasSingleRule) {
+      this.addRule();
+    }
   }
 
   changeNot(value: boolean): void {


### PR DESCRIPTION
## Summary
- add default rule when choosing AND/OR on a single-rule ruleset
- add unit test for auto-rule addition

## Testing
- `npm run prettier:check` (fails: Code style issues found in 90 files)
- `CI=true npm test` (fails: Unexpected "SelectorUpdateComponent" found in the "declarations" array...)


------
https://chatgpt.com/codex/tasks/task_e_688aa38aecd4832196310d6c75af2bbc