### PR TITLE
fix(query-builder): show all operators on hover

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -125,20 +125,20 @@
         </label>
       </div>
       <div [ngClass]="getClassNames('switchControl')"
-           *ngIf="data.condition === 'and' || (hoveringSwitchGroup && data.rules.length !== 1)">
+           *ngIf="data.condition === 'and' || hoveringSwitchGroup">
         <input type="radio" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.condition" [disabled]=disabled
                value="and" #andOption />
         <label (click)="changeCondition(andOption.value)" [ngClass]="getClassNames('switchLabel')">
-          <ng-container *ngIf="data.rules.length !== 1; else blankAnd">AND</ng-container>
+          <ng-container *ngIf="hoveringSwitchGroup || data.rules.length !== 1; else blankAnd">AND</ng-container>
           <ng-template #blankAnd><span class="q-switch-label-empty">&nbsp;</span></ng-template>
         </label>
       </div>
       <div [ngClass]="getClassNames('switchControl')"
-           *ngIf="data.condition === 'or' || (hoveringSwitchGroup && data.rules.length !== 1)">
+           *ngIf="data.condition === 'or' || hoveringSwitchGroup">
         <input type="radio" [ngClass]="getClassNames('switchRadio')" [(ngModel)]="data.condition" [disabled]=disabled
                value="or" #orOption />
         <label (click)="changeCondition(orOption.value)" [ngClass]="getClassNames('switchLabel')">
-          <ng-container *ngIf="data.rules.length !== 1; else blankOr">OR</ng-container>
+          <ng-container *ngIf="hoveringSwitchGroup || data.rules.length !== 1; else blankOr">OR</ng-container>
           <ng-template #blankOr><span class="q-switch-label-empty">&nbsp;</span></ng-template>
         </label>
       </div>


### PR DESCRIPTION
## Summary
- reveal AND/OR when hovering operator switch in query builder

## Testing
- `npm test` *(fails: 5 failed, 41 passed)*
- `dotnet test` *(fails: 4 failed, 59 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688aa85a17b883219864422ce69e9911