### PR TITLE
fix: set default operator when query is empty

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.spec.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.spec.ts
@@ -1,0 +1,14 @@
+import { QueryInputComponent } from './query-input.component';
+import { MatDialog } from '@angular/material/dialog';
+import { RuleSet, Rule } from 'ngx-query-builder';
+
+describe('QueryInputComponent', () => {
+  it('should set default operator when parsing empty query', () => {
+    const component = new QueryInputComponent({} as MatDialog);
+    component.defaultRuleAttribute = 'document';
+    const rs: RuleSet = component.parseQuery('');
+    const rule = rs.rules[0] as Rule;
+    expect(rule.field).toBe('document');
+    expect(rule.operator).toBe('contains');
+  });
+});

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.ts
@@ -189,7 +189,21 @@ export class QueryInputComponent implements OnInit {
     if (!trimmed) {
       const fields = Object.keys(this.queryBuilderConfig.fields);
       const attr = this.defaultRuleAttribute || fields[0];
-      const rule = attr ? ({ field: attr } as Rule) : undefined;
+      let operator: string | undefined;
+      if (attr) {
+        const fieldCfg = this.queryBuilderConfig.fields[attr];
+        if (fieldCfg) {
+          if (fieldCfg.defaultOperator !== undefined) {
+            operator =
+              typeof fieldCfg.defaultOperator === 'function'
+                ? fieldCfg.defaultOperator()
+                : fieldCfg.defaultOperator;
+          } else if (fieldCfg.operators && fieldCfg.operators.length) {
+            operator = fieldCfg.operators[0];
+          }
+        }
+      }
+      const rule = attr ? ({ field: attr, operator } as Rule) : undefined;
       return { condition: 'and', rules: rule ? [rule] : [] };
     }
 


### PR DESCRIPTION
## Summary
- ensure query builder sets default operator when starting with no query
- test parsing empty query selects `contains` operator

## Testing
- `npm test -w src/JhipsterSampleApplication/ClientApp/` *(fails: Unexpected "SelectorUpdateComponent" found in the "declarations" array...)*
- `npx ng test popup-ngx-query-builder --watch=false` *(fails: Cannot find module 'karma-jasmine')*


------
https://chatgpt.com/codex/tasks/task_e_6890e0b60f808321a2736df812ddc089