### PR TITLE
feat(query-builder): omit quotes for regex in CONTAINS

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
@@ -120,6 +120,18 @@ describe('BQL named ruleset support', () => {
     expect(rulesetToBql(rs, cfg)).toBe('fname !CONTAINS bob');
   });
 
+  it('should parse and stringify CONTAINS regex without quotes', () => {
+    const cfg: QueryBuilderConfig = {
+      fields: { document: { type: 'string', operators: ['contains'] } },
+    } as any;
+    const rs = bqlToRuleset('/ani/', cfg);
+    const r = rs.rules[0] as Rule;
+    expect(r.field).toBe('document');
+    expect(r.operator).toBe('contains');
+    expect(r.value).toBe('/ani/');
+    expect(rulesetToBql(rs, cfg)).toBe('/ani/');
+  });
+
   it('should parse and stringify !LIKE operator', () => {
     const cfg: QueryBuilderConfig = {
       fields: { fname: { type: 'string', operators: ['like', '!like'] } },

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.ts
@@ -386,6 +386,9 @@ export function rulesetToBql(rs: RuleSet, config: QueryBuilderConfig): string {
       rule.field === 'document' &&
       rule.operator.toLowerCase() === 'contains'
     ) {
+      if (typeof rule.value === 'string' && /^\/.*\/[gimsuy]*$/.test(rule.value)) {
+        return rule.value;
+      }
       return valueToString(rule.value);
     }
     const op = toOperatorToken(rule.operator);


### PR DESCRIPTION
## Summary
- output regex values without quotes when converting `document CONTAINS` rules to BQL
- test regex round-trip for CONTAINS

## Testing
- `npx ng test popup-ngx-query-builder --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `npm test` *(fails: Selector component tests misconfigured)*
- `dotnet test` *(fails: 4 failed, 59 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6890e72499008321941714cc296e606d