### PR TITLE
Handle regex flags in BQL conversion

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
@@ -132,6 +132,18 @@ describe('BQL named ruleset support', () => {
     expect(rulesetToBql(rs, cfg)).toBe('/ani/');
   });
 
+  it('should parse and stringify CONTAINS regex with flags without quotes', () => {
+    const cfg: QueryBuilderConfig = {
+      fields: { document: { type: 'string', operators: ['contains'] } },
+    } as any;
+    const rs = bqlToRuleset('/dani/i', cfg);
+    const r = rs.rules[0] as Rule;
+    expect(r.field).toBe('document');
+    expect(r.operator).toBe('contains');
+    expect(r.value).toBe('/dani/i');
+    expect(rulesetToBql(rs, cfg)).toBe('/dani/i');
+  });
+
   it('should parse and stringify !LIKE operator', () => {
     const cfg: QueryBuilderConfig = {
       fields: { fname: { type: 'string', operators: ['like', '!like'] } },

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.ts
@@ -374,6 +374,9 @@ function valueToString(value: any): string {
   if (Array.isArray(value)) {
     return '(' + value.map((v) => valueToString(v)).join(',') + ')';
   }
+  if (value instanceof RegExp) {
+    return value.toString();
+  }
   if (typeof value === 'string' && /^[A-Za-z0-9._-]+$/.test(value)) {
     return value;
   }
@@ -386,6 +389,9 @@ export function rulesetToBql(rs: RuleSet, config: QueryBuilderConfig): string {
       rule.field === 'document' &&
       rule.operator.toLowerCase() === 'contains'
     ) {
+      if (rule.value instanceof RegExp) {
+        return rule.value.toString();
+      }
       if (typeof rule.value === 'string' && /^\/.*\/[gimsuy]*$/.test(rule.value)) {
         return rule.value;
       }


### PR DESCRIPTION
## Summary
- allow `rulesetToBql` to emit regex literals when `Rule.value` is a RegExp
- cover regex values with flags in query-builder tests

## Testing
- `npm test` *(fails: Schema validation failed; Selector* components misconfigured)*

------
https://chatgpt.com/codex/tasks/task_e_6890efdbe97c832191a192d977a1593f