### PR TITLE
feat: handle regex in BQL CONTAINS conversion

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/filter/bql-converter.spec.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/filter/bql-converter.spec.ts
@@ -1,0 +1,23 @@
+import { jsonToBql } from './bql-converter';
+
+describe('jsonToBql', () => {
+  it('converts regex without quotes', () => {
+    const q = { document: { CONTAINS: '/ani/' } };
+    expect(jsonToBql(q)).toBe('document CONTAINS /ani/');
+  });
+
+  it('converts regex with flags', () => {
+    const q = { document: { CONTAINS: '/dani/i' } };
+    expect(jsonToBql(q)).toBe('document CONTAINS /dani/i');
+  });
+
+  it('converts RegExp instance', () => {
+    const q = { document: { CONTAINS: /ani/ } };
+    expect(jsonToBql(q)).toBe('document CONTAINS /ani/');
+  });
+
+  it('wraps normal strings in quotes', () => {
+    const q = { document: { CONTAINS: 'ani' } };
+    expect(jsonToBql(q)).toBe('document CONTAINS "ani"');
+  });
+});

--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/filter/bql-converter.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/filter/bql-converter.ts
@@ -1,0 +1,38 @@
+export interface BqlCondition {
+  CONTAINS?: unknown;
+  [key: string]: unknown;
+}
+
+export type BqlJson = Record<string, unknown>;
+
+const regexLike = /^\/.*\/[gimsuy]*$/;
+
+function isRegexExpression(value: unknown): value is string {
+  return typeof value === 'string' && regexLike.test(value);
+}
+
+export function jsonToBql(json: BqlJson): string {
+  const [field, condition] = Object.entries(json)[0] ?? [];
+  if (!field || typeof condition !== 'object' || condition === null) {
+    return '';
+  }
+
+  const cond = condition as BqlCondition;
+
+  if ('CONTAINS' in cond) {
+    const raw = cond.CONTAINS;
+    let expression: string;
+    if (raw instanceof RegExp) {
+      expression = raw.toString();
+    } else if (isRegexExpression(raw)) {
+      expression = raw;
+    } else {
+      expression = `"${String(raw)}"`;
+    }
+    return `${field} CONTAINS ${expression}`;
+  }
+
+  return '';
+}
+
+export { isRegexExpression };


### PR DESCRIPTION
## Summary
- add jsonToBql helper that detects regex-style strings and emits them unquoted
- cover regex and plain string cases with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689144ca9e0c8321bc09c879d5eef5b4