### PR TITLE
Handle regex in BQL contains conversion

### DIFF
--- a/src/JhipsterSampleApplication.Domain.Services/BirthdayBqlService.cs
+++ b/src/JhipsterSampleApplication.Domain.Services/BirthdayBqlService.cs
@@ -476,7 +476,7 @@ namespace JhipsterSampleApplication.Domain.Services
                 else if (r.field == "document" && r.value != null)
                 {
                     var valStr = r.value.ToString();
-                    if (valStr != null && Regex.IsMatch(valStr, "^/.*/"))
+                    if (valStr != null && Regex.IsMatch(valStr, @"^/.*/i?$", RegexOptions.IgnoreCase))
                     {
                         result.Append(valStr); // regex
                     }
@@ -509,7 +509,7 @@ namespace JhipsterSampleApplication.Domain.Services
                         if (r.value != null)
                         {
                             var valStr = r.value.ToString();
-                            if (valStr != null && valStr.StartsWith("/") && (valStr.EndsWith("/") || valStr.EndsWith("/i")))
+                            if (valStr != null && Regex.IsMatch(valStr, @"^/.*/i?$", RegexOptions.IgnoreCase))
                             {
                                 result.Append(valStr); // regex
                             }

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
@@ -169,6 +169,32 @@ describe('BQL named ruleset support', () => {
   });
 });
 
+describe('BQL regex support', () => {
+  const cfg: QueryBuilderConfig = {
+    fields: { document: { type: 'string', operators: ['contains'] } },
+  } as any;
+
+  it('should omit quotes for regex values', () => {
+    const rs: RuleSet = {
+      condition: 'and',
+      rules: [
+        { field: 'document', operator: 'contains', value: '/ani/' } as Rule,
+      ],
+    } as any;
+    expect(rulesetToBql(rs, cfg)).toBe('/ani/');
+  });
+
+  it('should handle regex flags', () => {
+    const rs: RuleSet = {
+      condition: 'and',
+      rules: [
+        { field: 'document', operator: 'contains', value: '/dani/i' } as Rule,
+      ],
+    } as any;
+    expect(rulesetToBql(rs, cfg)).toBe('/dani/i');
+  });
+});
+
 describe('validateBql', () => {
   const cfg: QueryBuilderConfig = {
     fields: {

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.ts
@@ -374,8 +374,13 @@ function valueToString(value: any): string {
   if (Array.isArray(value)) {
     return '(' + value.map((v) => valueToString(v)).join(',') + ')';
   }
-  if (typeof value === 'string' && /^[A-Za-z0-9._-]+$/.test(value)) {
-    return value;
+  if (typeof value === 'string') {
+    if (/^\/.*\/i?$/.test(value)) {
+      return value;
+    }
+    if (/^[A-Za-z0-9._-]+$/.test(value)) {
+      return value;
+    }
   }
   return JSON.stringify(value);
 }

--- a/test/JhipsterSampleApplication.Test/DomainServices/BirthdayBqlServiceTest.cs
+++ b/test/JhipsterSampleApplication.Test/DomainServices/BirthdayBqlServiceTest.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using JhipsterSampleApplication.Domain.Services;
+using JhipsterSampleApplication.Domain.Services.Interfaces;
+using JhipsterSampleApplication.Dto;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace JhipsterSampleApplication.Test.DomainServices;
+
+public class BirthdayBqlServiceTest
+{
+    private readonly BirthdayBqlService _service;
+
+    public BirthdayBqlServiceTest()
+    {
+        var namedQueryService = new Mock<INamedQueryService>().Object;
+        _service = new BirthdayBqlService(NullLogger<BirthdayBqlService>.Instance, namedQueryService);
+    }
+
+    [Theory]
+    [InlineData("/ani/")]
+    [InlineData("/dani/i")]
+    public async Task Ruleset2Bql_ShouldReturnRegexWithoutQuotes(string pattern)
+    {
+        var ruleset = new RulesetDto
+        {
+            condition = "and",
+            rules = new List<RulesetDto>
+            {
+                new RulesetDto { field = "document", @operator = "contains", value = pattern }
+            }
+        };
+
+        var result = await _service.Ruleset2Bql(ruleset);
+
+        Assert.Equal(pattern, result);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure JSON to BQL conversion recognizes regex literals
- test regex conversion in client and server

## Testing
- `npm test` *(fails: Selector components missing from imports; routing resolve service type errors; selector delete dialog type mismatch)*
- `dotnet test` *(fails: BirthdaysControllerIntTest TestBqlOperations, TestViewOperations, TestCreateAndGetBirthday, TestComplexBqlOperations)*

------
https://chatgpt.com/codex/tasks/task_e_689147c813c483219b22bd6b44b3f41d