### PR TITLE
feat: show no hits when search returns nothing

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/shared/data-loader.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/shared/data-loader.ts
@@ -49,7 +49,7 @@ export class DataLoader<T> {
     filter?: any,
   ): void {
     this.loadingSubject.next(true);
-    this.loadingMessageSubject.next('loading...');
+    this.loadingMessageSubject.next('Loading... ');
 
     this.itemsPerPage = itemsPerPage;
     this.predicate = predicate;
@@ -126,6 +126,13 @@ export class DataLoader<T> {
 
     const currentLength = this.buffer.length;
     const totalItems = this.totalItemsSubject.getValue();
+
+    if (totalItems === 0) {
+      this.bufferSubject.next([...this.buffer]);
+      this.loadingMessageSubject.next('No hits');
+      this.loadingSubject.next(true);
+      return;
+    }
 
     if (currentLength >= this.dataLoadLimit) {
       if (totalItems > this.dataLoadLimit) {


### PR DESCRIPTION
## Summary
- show `Loading...` initially when data loading starts
- display `No hits` when a search returns zero results

## Testing
- `npm test` (fails: Schema validation error; tests for selector components failing)

------
https://chatgpt.com/codex/tasks/task_e_68915a86bcb88321b0da46c8eb3ad292