### PR TITLE
Fix refresh list button to reissue current query

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
@@ -413,7 +413,7 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
 
   refreshData(): void {
     console.log('refreshData called');
-    
+
     try {
       this.syncSortFilterFromHeader();
       if (this.viewMode === 'group') {
@@ -421,19 +421,14 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
           this.superTable.expandedRowKeys,
         ).filter(key => this.groups.find(g => g.name === key));
       }
-      if (this.viewName) {
-        this.loadRootGroups(true);
-        setTimeout(() => {
-          this.superTable.applyCapturedHeaderState();
-          (this.superTable as any).applyStoredStateToDetails();
-        },1000);
-      } else {
-        this.loadPage();
-        setTimeout(() => {
-          this.superTable.applyCapturedHeaderState();
-          (this.superTable as any).applyStoredStateToDetails();
-        },1000);        
-      }
+
+      // Always re-issue the current query (BQL or lucene '*')
+      this.onQueryChange(this.currentQuery);
+
+      setTimeout(() => {
+        this.superTable.applyCapturedHeaderState();
+        (this.superTable as any).applyStoredStateToDetails();
+      }, 1000);
     } catch (error) {
       console.error('Error in refreshData:', error);
       this.forceResetLoading();


### PR DESCRIPTION
## Summary
- ensure birthday list refresh button reissues current BQL or wildcard query

## Testing
- `npm test` *(fails: unexpected "SelectorUpdateComponent"...)*
- `dotnet test --no-build --verbosity minimal` *(fails: 4 failed, 61 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6892345ee1988321baea2699afcdd9c3