### PR TITLE
feat: add range operator support to BQL to Elasticsearch conversion

### DIFF
--- a/src/JhipsterSampleApplication.Domain.Services/BirthdayService.cs
+++ b/src/JhipsterSampleApplication.Domain.Services/BirthdayService.cs
@@ -304,6 +304,31 @@ public class BirthdayService : IBirthdayService
                     }}
                 }};
             }
+            else if (rr.@operator == ">" || rr.@operator == "<" || rr.@operator == ">=" || rr.@operator == "<=")
+            {
+                var rangeOperator = rr.@operator switch
+                {
+                    ">" => "gt",
+                    ">=" => "gte",
+                    "<" => "lt",
+                    "<=" => "lte",
+                    _ => string.Empty
+                };
+
+                ret = new JObject
+                {
+                    {
+                        "range",
+                        new JObject
+                        {
+                            {
+                                rr.field!,
+                                new JObject { { rangeOperator, rr.value?.ToString() ?? string.Empty } }
+                            }
+                        }
+                    }
+                };
+            }
             else if (rr.@operator?.Contains("=") == true)
             {
                 var valueStr = rr.value as string ?? string.Empty;

--- a/test/JhipsterSampleApplication.Test/DomainServices/BirthdayServiceRangeQueryTest.cs
+++ b/test/JhipsterSampleApplication.Test/DomainServices/BirthdayServiceRangeQueryTest.cs
@@ -1,0 +1,56 @@
+using System.Threading.Tasks;
+using JhipsterSampleApplication.Domain.Entities;
+using JhipsterSampleApplication.Domain.Services;
+using JhipsterSampleApplication.Domain.Services.Interfaces;
+using Moq;
+using Nest;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace JhipsterSampleApplication.Test.DomainServices;
+
+public class BirthdayServiceRangeQueryTest
+{
+    private readonly BirthdayService _service;
+
+    public BirthdayServiceRangeQueryTest()
+    {
+        var elasticClient = new Mock<IElasticClient>().Object;
+        var bqlService = new Mock<IBirthdayBqlService>().Object;
+        var viewService = new Mock<IViewService>().Object;
+        _service = new BirthdayService(elasticClient, bqlService, viewService);
+    }
+
+    [Theory]
+    [InlineData(">", "gt")]
+    [InlineData(">=", "gte")]
+    [InlineData("<", "lt")]
+    [InlineData("<=", "lte")]
+    public async Task ConvertRulesetToElasticSearch_HandlesRangeOperators(string op, string expected)
+    {
+        var ruleset = new Ruleset
+        {
+            field = "dob",
+            @operator = op,
+            value = "1990-01-01"
+        };
+
+        var result = await _service.ConvertRulesetToElasticSearch(ruleset);
+
+        var expectedObject = new JObject
+        {
+            {
+                "range",
+                new JObject
+                {
+                    {
+                        "dob",
+                        new JObject { { expected, "1990-01-01" } }
+                    }
+                }
+            }
+        };
+
+        Assert.True(JToken.DeepEquals(expectedObject, result));
+    }
+}


### PR DESCRIPTION
## Summary
- support >, >=, <, <= operators when converting rulesets to Elasticsearch queries
- add unit tests for range operator conversion

## Testing
- `dotnet test test/JhipsterSampleApplication.Test/JhipsterSampleApplication.Test.csproj --filter "FullyQualifiedName~BirthdayBqlServiceTest|FullyQualifiedName~BirthdayServiceRangeQueryTest"`


------
https://chatgpt.com/codex/tasks/task_e_68952cbad2d48321932fe97afaef8eea