### PR TITLE
Handle date-only values in ruleset range queries

### DIFF
--- a/src/JhipsterSampleApplication.Domain.Services/BirthdayService.cs
+++ b/src/JhipsterSampleApplication.Domain.Services/BirthdayService.cs
@@ -315,6 +315,12 @@ public class BirthdayService : IBirthdayService
                     _ => string.Empty
                 };
 
+                var valueString = rr.value?.ToString() ?? string.Empty;
+                if (DateTime.TryParse(valueString, out var dateValue))
+                {
+                    valueString = dateValue.ToString("yyyy-MM-dd'T'HH:mm:ss");
+                }
+
                 ret = new JObject
                 {
                     {
@@ -323,7 +329,7 @@ public class BirthdayService : IBirthdayService
                         {
                             {
                                 rr.field!,
-                                new JObject { { rangeOperator, rr.value?.ToString() ?? string.Empty } }
+                                new JObject { { rangeOperator, valueString } }
                             }
                         }
                     }

--- a/test/JhipsterSampleApplication.Test/DomainServices/BirthdayServiceRangeQueryTest.cs
+++ b/test/JhipsterSampleApplication.Test/DomainServices/BirthdayServiceRangeQueryTest.cs
@@ -45,7 +45,36 @@ public class BirthdayServiceRangeQueryTest
                 {
                     {
                         "dob",
-                        new JObject { { expected, "1990-01-01" } }
+                        new JObject { { expected, "1990-01-01T00:00:00" } }
+                    }
+                }
+            }
+        };
+
+        Assert.True(JToken.DeepEquals(expectedObject, result));
+    }
+
+    [Fact]
+    public async Task ConvertRulesetToElasticSearch_PreservesDateTimeValues()
+    {
+        var ruleset = new Ruleset
+        {
+            field = "dob",
+            @operator = ">",
+            value = "1990-01-01T12:34:56"
+        };
+
+        var result = await _service.ConvertRulesetToElasticSearch(ruleset);
+
+        var expectedObject = new JObject
+        {
+            {
+                "range",
+                new JObject
+                {
+                    {
+                        "dob",
+                        new JObject { { "gt", "1990-01-01T12:34:56" } }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- format range query values as ISO timestamps during ruleset->Elasticsearch conversion
- extend BirthdayServiceRangeQueryTest for date and datetime cases

## Testing
- `dotnet build src/JhipsterSampleApplication.Domain.Services/JhipsterSampleApplication.Domain.Services.csproj`
- `dotnet test test/JhipsterSampleApplication.Test/JhipsterSampleApplication.Test.csproj` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a42bafcc48321a775ad4587ff0b6b