### PR TITLE
feat: support partial date queries

### DIFF
--- a/src/JhipsterSampleApplication.Domain.Services/BirthdayBqlService.cs
+++ b/src/JhipsterSampleApplication.Domain.Services/BirthdayBqlService.cs
@@ -413,7 +413,7 @@ namespace JhipsterSampleApplication.Domain.Services
             {
                 "isAlive" => value == "true" || value == "false",
                 "sign" => ValidSigns.Contains(value.ToLower()),
-                "dob" => Regex.IsMatch(value, @"^\d{4}-\d{2}-\d{2}$"),
+                "dob" => Regex.IsMatch(value, @"^\d{4}(-\d{2}(-\d{2}(T\d{2}:\d{2}:\d{2})?)?)?$"),
                 "lname" => !string.IsNullOrWhiteSpace(value),
                 "fname" => !string.IsNullOrWhiteSpace(value),
                 "document" => !string.IsNullOrWhiteSpace(value),


### PR DESCRIPTION
## Summary
- allow partial dob values (year, year-month, day) in BQL
- convert dob rules to appropriate range queries
- test date range handling for year, month, and day

## Testing
- `dotnet test -p:SkipClientBuild=true` *(fails: npm ENOENT, controller integration tests)*
- `dotnet test test/JhipsterSampleApplication.Test/JhipsterSampleApplication.Test.csproj -p:SkipClientBuild=true --filter BirthdayServiceRangeQueryTest`


------
https://chatgpt.com/codex/tasks/task_e_689a54b0b79483219b14e9536cf16a5d