### PR TITLE
feat(bql): validate partial dates in BQL queries

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
@@ -343,6 +343,20 @@ describe('validateBql', () => {
     expect(validateBql('sign IN (aries,taurus)', cfg5)).toBeFalse();
   });
 
+  it('should validate partial dates', () => {
+    const cfgDate: QueryBuilderConfig = {
+      fields: { dob: { name: 'Birthday', type: 'date', operators: ['='] } },
+    } as any;
+    expect(validateBql('dob=1992', cfgDate)).toBeTrue();
+    expect(validateBql('dob=1992-01', cfgDate)).toBeTrue();
+    expect(validateBql('dob=1992-01-03', cfgDate)).toBeTrue();
+    expect(validateBql('dob=1992-', cfgDate)).toBeFalse();
+    expect(validateBql('dob=1992-0', cfgDate)).toBeFalse();
+    expect(validateBql('dob=1992-01-', cfgDate)).toBeFalse();
+    expect(validateBql('dob=1992-01-0', cfgDate)).toBeFalse();
+    expect(validateBql('dob=1993-02-29', cfgDate)).toBeFalse();
+  });
+
   it('should reject named ruleset loops', () => {
     const cfgLoop: QueryBuilderConfig = {
       fields: {},

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.ts
@@ -126,6 +126,21 @@ function toOperatorToken(op: string): string {
   return op;
 }
 
+function isValidPartialDate(v: string): boolean {
+  if (/^\d{4}$/.test(v)) return true;
+  if (/^\d{4}-(0[1-9]|1[0-2])$/.test(v)) return true;
+  if (/^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/.test(v)) {
+    const [y, m, d] = v.split('-').map(Number);
+    const date = new Date(Date.UTC(y, m - 1, d));
+    return (
+      date.getUTCFullYear() === y &&
+      date.getUTCMonth() === m - 1 &&
+      date.getUTCDate() === d
+    );
+  }
+  return false;
+}
+
 function parseValue(
   token: Token,
   field: string,
@@ -137,7 +152,12 @@ function parseValue(
   const v = token.value;
   if (type === 'number') return Number(v);
   if (type === 'boolean') return v === 'true';
-  if (type === 'date') return new Date(v);
+  if (type === 'date') {
+    if (!isValidPartialDate(v)) {
+      throw new Error('Invalid date');
+    }
+    return new Date(v);
+  }
   return v;
 }
 


### PR DESCRIPTION
## Summary
- validate partial date values when parsing BQL
- cover valid and invalid date prefixes with unit tests

## Testing
- `npx ng test popup-ngx-query-builder --watch=false --browsers=ChromeHeadless` *(fails: Cannot find module 'karma-jasmine-html-reporter')*
- `npm run jest` *(fails: Jest encountered an unexpected token: Missing semicolon)*

------
https://chatgpt.com/codex/tasks/task_e_689a656d87748321b2dbc026c2cbb5c2