### PR TITLE
fix: correct category query escaping

### DIFF
--- a/src/JhipsterSampleApplication/Controllers/BirthdaysController.cs
+++ b/src/JhipsterSampleApplication/Controllers/BirthdaysController.cs
@@ -201,7 +201,7 @@ namespace JhipsterSampleApplication.Controllers
                 }
                 else
                 {
-                    string categoryQuery = string.IsNullOrEmpty(viewDto.CategoryQuery) ?  $"{viewDto.Aggregation}:\\\"{category}\\\"" : viewDto.CategoryQuery.Replace("{}", category);
+                    string categoryQuery = string.IsNullOrEmpty(viewDto.CategoryQuery) ?  $"{viewDto.Aggregation}:\"{category}\"" : viewDto.CategoryQuery.Replace("{}", category);
                     elasticsearchQuery = new JObject(
                         new JProperty("bool", new JObject(
                             new JProperty("must", new JArray(
@@ -259,7 +259,7 @@ namespace JhipsterSampleApplication.Controllers
                     }
                     else
                     {
-                        string secondaryCategoryQuery = string.IsNullOrEmpty(secondaryViewDto.CategoryQuery) ?  $"{secondaryViewDto.Aggregation}:\\\"{secondaryCategory}\\\"" : secondaryViewDto.CategoryQuery.Replace("{}", secondaryCategory);
+                        string secondaryCategoryQuery = string.IsNullOrEmpty(secondaryViewDto.CategoryQuery) ?  $"{secondaryViewDto.Aggregation}:\"{secondaryCategory}\"" : secondaryViewDto.CategoryQuery.Replace("{}", secondaryCategory);
                         elasticsearchQuery = new JObject(
                             new JProperty("bool", new JObject(
                                 new JProperty("must", new JArray(


### PR DESCRIPTION
## Summary
- fix category query escaping for view filtering

## Testing
- `dotnet test test/JhipsterSampleApplication.Test/JhipsterSampleApplication.Test.csproj --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_689ac66bb78c83219c80987927687b1d