### PR TITLE
feat: add regex like operator

### DIFF
--- a/src/JhipsterSampleApplication.Domain.Services/BirthdayService.cs
+++ b/src/JhipsterSampleApplication.Domain.Services/BirthdayService.cs
@@ -258,7 +258,7 @@ public class BirthdayService : IBirthdayService
                     "BOGUSFIELD", "CANTMATCH"
                 }}
             }};
-            if (rr.@operator?.Contains("contains") == true)
+            if (rr.@operator?.Contains("contains") == true || rr.@operator?.Contains("like") == true)
             {
                 string stringValue = rr.value?.ToString() ?? string.Empty;
                 if (stringValue.StartsWith("/") && (stringValue.EndsWith("/") || stringValue.EndsWith("/i")))

--- a/src/JhipsterSampleApplication.Domain.Services/GenericBqlService.cs
+++ b/src/JhipsterSampleApplication.Domain.Services/GenericBqlService.cs
@@ -140,6 +140,14 @@ namespace JhipsterSampleApplication.Domain.Services
                     .ToList() ?? new List<string>();
                 if (opsLower.Count > 0)
                 {
+                    if (opsLower.Contains("contains") && !opsLower.Contains("like"))
+                    {
+                        opsLower.Add("like");
+                    }
+                    if (opsLower.Contains("!contains") && !opsLower.Contains("!like"))
+                    {
+                        opsLower.Add("!like");
+                    }
                     _fieldOperatorsLowerByName[fieldName] = opsLower;
                 }
 
@@ -166,6 +174,14 @@ namespace JhipsterSampleApplication.Domain.Services
                     .Where(s => !string.IsNullOrWhiteSpace(s))
                     .Distinct()
                     .ToList() ?? new List<string>();
+                if (ops.Contains("contains") && !ops.Contains("like"))
+                {
+                    ops.Add("like");
+                }
+                if (ops.Contains("!contains") && !ops.Contains("!like"))
+                {
+                    ops.Add("!like");
+                }
                 _operatorMapLowerByType[type] = ops;
             }
 
@@ -205,7 +221,7 @@ namespace JhipsterSampleApplication.Domain.Services
                 @"|(""(\\""|\\\\|[^""])+\""|\/(\\\/|[^\/])+\/i?" +
                 (string.IsNullOrEmpty(fieldsAlt) ? string.Empty : @"|" + fieldsAlt) +
                 @")" +
-                @"|(=|!=|CONTAINS|!CONTAINS|EXISTS|!EXISTS|IN|!IN|>=|<=|>|<)" +
+                @"|(=|!=|CONTAINS|!CONTAINS|LIKE|!LIKE|EXISTS|!EXISTS|IN|!IN|>=|<=|>|<)" +
                 @"|(&|\||!)" +
                 @"|[^""/=!<>() ]+)\s*";
 
@@ -471,10 +487,11 @@ namespace JhipsterSampleApplication.Domain.Services
                         }
                     }
 
+                    var op = Regex.IsMatch(docValue ?? string.Empty, @"^/.*/i?$", RegexOptions.IgnoreCase) ? "like" : "contains";
                     return (true, index + 1, new RulesetDto
                     {
                         field = _defaultFullTextField,
-                        @operator = "contains",
+                        @operator = op,
                         value = docValue ?? string.Empty
                     });
                 }

--- a/src/JhipsterSampleApplication.Domain.Services/SupremeService.cs
+++ b/src/JhipsterSampleApplication.Domain.Services/SupremeService.cs
@@ -141,7 +141,7 @@ namespace JhipsterSampleApplication.Domain.Services
 						"match_none", new JObject{}
 					}
 				};
-				if (rr.@operator?.Contains("contains") == true)
+                                if (rr.@operator?.Contains("contains") == true || rr.@operator?.Contains("like") == true)
 				{
 					string stringValue = rr.value?.ToString() ?? string.Empty;
 					string quote = Regex.IsMatch(stringValue, "\\W") ? "\"" : string.Empty;

--- a/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -1378,7 +1378,7 @@ export class QueryBuilderComponent
             if (!this.isOperatorAllowed(rule)) {
               errorStore.push({ field: rule.field, operator: rule.operator, error: 'invalid-operator' });
             }
-            if (!this.hasAllowedRegexFlagsForContains(rule, field)) {
+            if (!this.hasAllowedRegexFlagsForLike(rule, field)) {
               errorStore.push({ field: rule.field, error: 'invalid-regex-flags' });
             }
           }
@@ -1404,9 +1404,9 @@ export class QueryBuilderComponent
     return typeof rule.operator === 'string' && allowedOperators.indexOf(rule.operator) !== -1;
   }
 
-  private hasAllowedRegexFlagsForContains(rule: Rule, field: Field): boolean {
+  private hasAllowedRegexFlagsForLike(rule: Rule, field: Field): boolean {
     const operator = rule.operator;
-    if (operator !== 'contains' && operator !== '!contains') {
+    if (operator !== 'like' && operator !== '!like') {
       return true;
     }
     const value = (rule as any).value;
@@ -1416,7 +1416,7 @@ export class QueryBuilderComponent
     // Match regex literals like /exp/ or /exp/i, allowing escaped slashes
     const match = value.match(/^\/(?:\\\/|\\.|[^\/])+\/([a-z]*)$/);
     if (!match) {
-      return true; // not a regex literal; normal contains value is fine
+      return true; // not a regex literal; normal like value is fine
     }
     const flags = match[1] || '';
     for (const ch of flags) {

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
@@ -171,15 +171,13 @@ describe('BQL named ruleset support', () => {
 
 describe('BQL regex support', () => {
   const cfg: QueryBuilderConfig = {
-    fields: { document: { type: 'string', operators: ['contains'] } },
+    fields: { document: { type: 'string', operators: ['like'] } },
   } as any;
 
   it('should omit quotes for regex values', () => {
     const rs: RuleSet = {
       condition: 'and',
-      rules: [
-        { field: 'document', operator: 'contains', value: '/ani/' } as Rule,
-      ],
+      rules: [{ field: 'document', operator: 'like', value: '/ani/' } as Rule],
     } as any;
     expect(rulesetToBql(rs, cfg)).toBe('/ani/');
   });
@@ -187,11 +185,17 @@ describe('BQL regex support', () => {
   it('should handle regex flags', () => {
     const rs: RuleSet = {
       condition: 'and',
-      rules: [
-        { field: 'document', operator: 'contains', value: '/dani/i' } as Rule,
-      ],
+      rules: [{ field: 'document', operator: 'like', value: '/dani/i' } as Rule],
     } as any;
     expect(rulesetToBql(rs, cfg)).toBe('/dani/i');
+  });
+
+  it('should parse regex literals as LIKE', () => {
+    const rs = bqlToRuleset('/dani/i', cfg);
+    const r = rs.rules[0] as Rule;
+    expect(r.field).toBe('document');
+    expect(r.operator).toBe('like');
+    expect(r.value).toBe('/dani/i');
   });
 });
 

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.ts
@@ -91,7 +91,7 @@ export class QueryInputComponent implements OnInit {
       document: {
         name: 'Document',
         type: 'string',
-        operators: ['contains', '!contains'],
+        operators: ['contains', '!contains', 'like', '!like'],
         defaultOperator: 'contains',
       },
     },

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
@@ -234,7 +234,7 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
             if (s) terms.push(s);
           };
           // document contains "x" or generic value searches should highlight value
-          if (operator && (operator.includes('contains') || operator === '=' || operator === '==' || operator === 'in' || operator === 'not in')) {
+          if (operator && (operator.includes('contains') || operator.includes('like') || operator === '=' || operator === '==' || operator === 'in' || operator === 'not in')) {
             if (Array.isArray(value)) value.forEach(pushVal);
             else pushVal(value);
           } else if (field === 'document') {

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/supreme/bql-help.txt
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/supreme/bql-help.txt
@@ -5,4 +5,4 @@ Supported BQL fields for Supreme:
 - majority, minority, advocates
 - question, facts_of_the_case, conclusion, description, opinion
 - justia_url, recused
-Operators: =, !=, CONTAINS, !CONTAINS, LIKE, EXISTS, !EXISTS, IN, !IN
+Operators: =, !=, CONTAINS, !CONTAINS, LIKE, !LIKE, EXISTS, !EXISTS, IN, !IN

--- a/src/JhipsterSampleApplication/Resources/query-builder/birthday-qb-spec.json
+++ b/src/JhipsterSampleApplication/Resources/query-builder/birthday-qb-spec.json
@@ -3,7 +3,7 @@
     "document": {
       "name": "Document",
       "type": "string",
-      "operators": ["contains", "!contains"]
+      "operators": ["contains", "!contains", "like", "!like"]
     },
     "lname": {
       "name": "Last Name",
@@ -22,7 +22,7 @@
     "categories": {
       "name": "Category",
       "type": "string",
-      "operators": ["contains", "!contains", "exists"]
+      "operators": ["contains", "!contains", "like", "!like", "exists"]
     },
     "dob": {
       "name": "Birthday",

--- a/src/JhipsterSampleApplication/Resources/query-builder/supreme-qb-spec.json
+++ b/src/JhipsterSampleApplication/Resources/query-builder/supreme-qb-spec.json
@@ -3,7 +3,7 @@
     "document": {
       "name": "Document",
       "type": "string",
-      "operators": ["contains", "!contains"]
+      "operators": ["contains", "!contains", "like", "!like"]
     },
     "name": {
       "name": "Case Name",
@@ -48,37 +48,37 @@
     "majority": {
       "name": "Majority",
       "type": "string",
-      "operators": ["contains", "!contains", "exists"]
+      "operators": ["contains", "!contains", "like", "!like", "exists"]
     },
     "minority": {
       "name": "Minority",
       "type": "string",
-      "operators": ["contains", "!contains", "exists"]
+      "operators": ["contains", "!contains", "like", "!like", "exists"]
     },
     "advocates": {
       "name": "Advocates",
       "type": "string",
-      "operators": ["contains", "!contains", "exists"]
+      "operators": ["contains", "!contains", "like", "!like", "exists"]
     },
     "question": {
       "name": "Question",
       "type": "string",
-      "operators": ["contains", "!contains", "exists"]
+      "operators": ["contains", "!contains", "like", "!like", "exists"]
     },
     "facts_of_the_case": {
       "name": "Facts",
       "type": "string",
-      "operators": ["contains", "!contains", "exists"]
+      "operators": ["contains", "!contains", "like", "!like", "exists"]
     },
     "conclusion": {
       "name": "Conclusion",
       "type": "string",
-      "operators": ["contains", "!contains", "exists"]
+      "operators": ["contains", "!contains", "like", "!like", "exists"]
     },
     "description": {
       "name": "Description",
       "type": "string",
-      "operators": ["contains", "!contains", "exists"]
+      "operators": ["contains", "!contains", "like", "!like", "exists"]
     }
   },
   "operatorMap": {

--- a/test/JhipsterSampleApplication.Test/DomainServices/BirthdayBqlServiceTest.cs
+++ b/test/JhipsterSampleApplication.Test/DomainServices/BirthdayBqlServiceTest.cs
@@ -29,7 +29,7 @@ public class BirthdayBqlServiceTest
             condition = "and",
             rules = new List<RulesetDto>
             {
-                new RulesetDto { field = "document", @operator = "contains", value = pattern }
+                new RulesetDto { field = "document", @operator = "like", value = pattern }
             }
         };
 

--- a/verification.txt
+++ b/verification.txt
@@ -12,7 +12,7 @@ Retains last column repositions from grid to group mode
 *Chip bar
 *Right click menus
 Save named rulesets in elasticsearch
-*CONTAINS regex
+*LIKE regex
 *No hits
 *V20
 Make category case-insensitive


### PR DESCRIPTION
## Summary
- move regex BQL matching from `contains` to `like`
- expose like and not like options across query builder and specs
- ensure backend and frontend validate regex flags for `like`

## Testing
- `dotnet test` *(fails: Expected addResp.StatusCode to be HttpStatusCode.OK {value: 200}, but found HttpStatusCode.InternalServerError {value: 500})*
- `npm test` *(fails: Parsing error: Unexpected token  prettier/prettier)*

------
https://chatgpt.com/codex/tasks/task_e_689de527e5d083219619948043c4b08b