### PR TITLE
fix: handle negated contains and like

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
@@ -270,6 +270,15 @@ describe('validateBql', () => {
     expect(validateBql('fname !LIKE bob', cfg4)).toBeTrue();
   });
 
+  it('should accept !LIKE when !contains is configured', () => {
+    const cfg: QueryBuilderConfig = {
+      fields: {
+        fname: { name: 'First', type: 'string', operators: ['!contains'] },
+      },
+    } as any;
+    expect(validateBql('fname !LIKE bob', cfg)).toBeTrue();
+  });
+
   it('should accept IN operator', () => {
     const cfg5: QueryBuilderConfig = {
       fields: {

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.ts
@@ -23,6 +23,12 @@ function getAllowedOperators(
   if (!operators || operators.length === 0) {
     operators = [];
   }
+  if (operators.includes('contains') && !operators.includes('like')) {
+    operators = operators.concat(['like']);
+  }
+  if (operators.includes('!contains') && !operators.includes('!like')) {
+    operators = operators.concat(['!like']);
+  }
   if (fieldConf.nullable) {
     operators = operators.concat(['is null', 'is not null']);
   }


### PR DESCRIPTION
## Summary
- ensure `getAllowedOperators` adds `like` and `!like` when `contains` or `!contains` are configured
- test validation of `!LIKE` when only `!contains` is configured

## Testing
- `npm test` *(fails: <button> should have content, prettier errors, etc.)*
- `dotnet test` *(fails: Failed tests in BirthdaysControllerIntTest, BirthdayControllerIntTest, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689deee82614832181a81ba69532ea84