### PR TITLE
Normalize negation operators in query builder and BQL

### DIFF
--- a/src/JhipsterSampleApplication.Domain.Services/GenericBqlService.cs
+++ b/src/JhipsterSampleApplication.Domain.Services/GenericBqlService.cs
@@ -241,7 +241,7 @@ namespace JhipsterSampleApplication.Domain.Services
                     return new[] { lowerOp };
                 case "in":
                     return new[] { "IN" };
-                case "not in":
+                case "!in":
                     return new[] { "!IN" };
                 case "contains":
                     return new[] { "CONTAINS" };
@@ -558,7 +558,7 @@ namespace JhipsterSampleApplication.Domain.Services
                     return (true, index + 1, new RulesetDto
                     {
                         field = field,
-                        @operator = opToken == "IN" ? "in" : "not in",
+                        @operator = opToken == "IN" ? "in" : "!in",
                         value = values ?? new List<string>()
                     });
                 }
@@ -690,7 +690,7 @@ namespace JhipsterSampleApplication.Domain.Services
                     {
                         result.Append(" " + (r.value is bool b && !b ? "!" : "") + "EXISTS ");
                     }
-                    else if (r.@operator == "in" || r.@operator == "not in")
+                    else if (r.@operator == "in" || r.@operator == "!in")
                     {
                         var values = r.value as IEnumerable<string> ?? new List<string>();
                         var quoted = values.Select(v => Regex.IsMatch(v, "^[a-zA-Z\\d]+$") ? v : "\"" + Regex.Replace(v ?? string.Empty, "([\\\"])", "\\$1") + "\"");

--- a/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.html
@@ -423,7 +423,7 @@
       >
         @for (operator of getOperators(rule.field); track operator) {
           <option [ngValue]="operator">
-            {{ operator }}
+            {{ displayOperator(operator) }}
           </option>
         }
       </select>

--- a/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/ngx-query-builder/src/lib/components/query-builder.component.ts
@@ -487,7 +487,7 @@ export class QueryBuilderComponent
       case 'is not null':
         return undefined; // No displayed component
       case 'in':
-      case 'not in':
+      case '!in':
         // Treat IN/NOT IN as multi-value for category, boolean, string, and number fields
         return type === 'category' || type === 'boolean' || type === 'string' || type === 'number'
           ? 'multiselect'
@@ -509,6 +509,19 @@ export class QueryBuilderComponent
       }
     }
     return conf.options || this.defaultEmptyList;
+  }
+
+  displayOperator(op: string): string {
+    switch (op) {
+      case '!contains':
+        return 'not contains';
+      case '!like':
+        return 'not like';
+      case '!in':
+        return 'not in';
+      default:
+        return op;
+    }
   }
 
   getClassNames(...args: any[]): string | undefined {
@@ -1348,7 +1361,7 @@ export class QueryBuilderComponent
         }
         return true;
       case 'category':
-        if (rule.operator === 'in' || rule.operator === 'not in') {
+        if (rule.operator === 'in' || rule.operator === '!in') {
           return !Array.isArray(val) || val.length === 0;
         }
         return val === undefined || val === null;
@@ -1357,7 +1370,7 @@ export class QueryBuilderComponent
       case 'multiselect':
         if (!Array.isArray(val)) return true;
         // For IN/NOT IN operators, require at least one selected value
-        if (rule.operator === 'in' || rule.operator === 'not in') {
+        if (rule.operator === 'in' || rule.operator === '!in') {
           return val.length === 0;
         }
         return false;

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.spec.ts
@@ -142,6 +142,17 @@ describe('BQL named ruleset support', () => {
     expect(rulesetToBql(rs, cfg)).toBe('sign IN (aries,taurus)');
   });
 
+  it('should parse and stringify !IN operator', () => {
+    const cfg: QueryBuilderConfig = {
+      fields: { sign: { type: 'string', operators: ['!in'] } },
+    } as any;
+    const rs = bqlToRuleset('sign !IN (aries,taurus)', cfg);
+    const r = rs.rules[0] as Rule;
+    expect(r.operator).toBe('!in');
+    expect(r.value).toEqual(['aries', 'taurus']);
+    expect(rulesetToBql(rs, cfg)).toBe('sign !IN (aries,taurus)');
+  });
+
   it('should parse IN operator with quoted value', () => {
     const cfg: QueryBuilderConfig = {
       fields: { sign: { type: 'string', operators: ['in'] } },

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/bql.ts
@@ -90,7 +90,7 @@ function tokenize(input: string): Token[] {
       const word = input.slice(i, j);
       const up = word.toUpperCase();
       if (
-        (up === '!CONTAINS' || up === '!LIKE') &&
+        (up === '!CONTAINS' || up === '!LIKE' || up === '!IN') &&
         (j === input.length || /\s|\(|\)|!|&|\||=|<|>|"/.test(input[j]))
       ) {
         tokens.push({ type: 'operator', value: up });
@@ -266,11 +266,11 @@ export function bqlToRuleset(
         peek().value.toLowerCase() === 'in'
       ) {
         consume();
-        operator = 'not in';
+        operator = '!in';
       }
 
       if (
-        (operator === 'in' || operator === 'not in') &&
+        (operator === 'in' || operator === '!in') &&
         peek() &&
         peek().value === '('
       ) {
@@ -544,7 +544,7 @@ function validateRule(
     return false;
   }
 
-  if (rule.operator === 'in' || rule.operator === 'not in') {
+  if (rule.operator === 'in' || rule.operator === '!in') {
     if (!Array.isArray(rule.value) || rule.value.length === 0) {
       return false;
     }
@@ -593,7 +593,7 @@ function validateRule(
     allowedValues &&
     allowedValues.length
   ) {
-    if (rule.operator === 'in' || rule.operator === 'not in') {
+    if (rule.operator === 'in' || rule.operator === '!in') {
       if (
         !Array.isArray(rule.value) ||
         !rule.value.every((v: any) => allowedValues!.includes(v))

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
@@ -234,7 +234,7 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
             if (s) terms.push(s);
           };
           // document contains "x" or generic value searches should highlight value
-          if (operator && (operator.includes('contains') || operator.includes('like') || operator === '=' || operator === '==' || operator === 'in' || operator === 'not in')) {
+          if (operator && (operator.includes('contains') || operator.includes('like') || operator === '=' || operator === '==' || operator === 'in' || operator === '!in')) {
             if (Array.isArray(value)) value.forEach(pushVal);
             else pushVal(value);
           } else if (field === 'document') {

--- a/src/JhipsterSampleApplication/Resources/query-builder/birthday-qb-spec.json
+++ b/src/JhipsterSampleApplication/Resources/query-builder/birthday-qb-spec.json
@@ -8,12 +8,12 @@
     "lname": {
       "name": "Last Name",
       "type": "string",
-      "operators": ["=", "!=", "contains", "!contains", "like", "!like", "in", "not in"]
+      "operators": ["=", "!=", "contains", "!contains", "like", "!like", "in", "!in"]
     },
     "fname": {
       "name": "First Name",
       "type": "string",
-      "operators": ["=", "!=", "contains", "!contains", "like", "!like", "in", "not in", "exists"]
+      "operators": ["=", "!=", "contains", "!contains", "like", "!like", "in", "!in", "exists"]
     },
     "isAlive": {
       "name": "Alive?",
@@ -49,11 +49,11 @@
     }
   },
   "operatorMap": {
-    "string": ["=", "!=", "contains", "!contains", "like", "!like", "in", "not in"],
-    "number": ["=", "!=", ">", ">=", "<", "<=", "in", "not in"],
+    "string": ["=", "!=", "contains", "!contains", "like", "!like", "in", "!in"],
+    "number": ["=", "!=", ">", ">=", "<", "<=", "in", "!in"],
     "time": ["=", "!=", ">", ">=", "<", "<="],
     "date": ["=", "!=", ">", ">=", "<", "<="],
-    "category": ["=", "!=", "in", "not in"],
+    "category": ["=", "!=", "in", "!in"],
     "boolean": ["="]
   }
 }

--- a/src/JhipsterSampleApplication/Resources/query-builder/supreme-qb-spec.json
+++ b/src/JhipsterSampleApplication/Resources/query-builder/supreme-qb-spec.json
@@ -8,12 +8,12 @@
     "name": {
       "name": "Case Name",
       "type": "string",
-      "operators": ["=", "!=", "contains", "!contains", "like", "!like", "in", "not in", "exists"]
+      "operators": ["=", "!=", "contains", "!contains", "like", "!like", "in", "!in", "exists"]
     },
     "term": {
       "name": "Term",
       "type": "string",
-      "operators": ["=", "!=", "in", "not in", "exists"]
+      "operators": ["=", "!=", "in", "!in", "exists"]
     },
     "docket_number": {
       "name": "Docket #",
@@ -82,11 +82,11 @@
     }
   },
   "operatorMap": {
-    "string": ["=", "!=", "contains", "!contains", "like", "!like", "in", "not in"],
-    "number": ["=", "!=", ">", ">=", "<", "<=", "in", "not in"],
+    "string": ["=", "!=", "contains", "!contains", "like", "!like", "in", "!in"],
+    "number": ["=", "!=", ">", ">=", "<", "<=", "in", "!in"],
     "time": ["=", "!=", ">", ">=", "<", "<="],
     "date": ["=", "!=", ">", ">=", "<", "<="],
-    "category": ["=", "!=", "in", "not in"],
+    "category": ["=", "!=", "in", "!in"],
     "boolean": ["="]
   }
 }


### PR DESCRIPTION
## Summary
- display `!` operators as `not` labels in the query builder
- standardize negated operators to `!in`, `!contains`, and `!like` across specs and backend
- accept and emit `!IN`, `!CONTAINS`, and `!LIKE` in BQL

## Testing
- `npm test` *(fails: @angular-eslint/template/elements-content, prettier)*
- `dotnet test` *(fails: JhipsterSampleApplication.Test.Controllers.BirthdaysControllerIntTest)*

------
https://chatgpt.com/codex/tasks/task_e_689e81d683e08321a4e1e41d2863efd4