### PR TITLE
feat(birthday): filter views by domain

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.ts
@@ -446,7 +446,7 @@ export class BirthdayComponent implements OnInit, AfterViewInit {
   }
 
   loadViews(): void {
-    this.viewService.query().subscribe((res) => {
+    this.viewService.queryByDomain('birthdays').subscribe((res) => {
       const body = res.body ?? [];
       this.views = body.map((v) => ({ label: v.name, value: v.id! }));
     });


### PR DESCRIPTION
## Summary
- filter birthday view dropdown by querying only 'birthdays' domain

## Testing
- `npm test` *(fails: <button> should have content, prettier errors)*
- `dotnet test` *(fails: 6 tests in BirthdaysControllerIntTest)*

------
https://chatgpt.com/codex/tasks/task_e_689e86d2cb3483218aab019fe8e792a0