### PR TITLE
feat(supreme): add missing endpoints and shared dtos

### DIFF
--- a/src/JhipsterSampleApplication.Domain/Entities/Supreme.cs
+++ b/src/JhipsterSampleApplication.Domain/Entities/Supreme.cs
@@ -27,10 +27,11 @@ namespace JhipsterSampleApplication.Domain.Entities
 			public string? Appellee { get; set; }
 			public string? Petitioner { get; set; }
 			public string? Respondent { get; set; }
-		public List<string>? Recused { get; set; }
-		public List<string>? Majority { get; set; }
-		public List<string>? Minority { get; set; }
-		public List<string>? Advocates { get; set; }
+                public List<string>? Recused { get; set; }
+                public List<string>? Majority { get; set; }
+                public List<string>? Minority { get; set; }
+                public List<string>? Advocates { get; set; }
+                [PropertyName("categories")] public List<string> Categories { get; set; } = new List<string>();
 
 		public override bool Equals(object? obj)
 		{

--- a/src/JhipsterSampleApplication.Dto/CategorizeMultipleRequestDto.cs
+++ b/src/JhipsterSampleApplication.Dto/CategorizeMultipleRequestDto.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace JhipsterSampleApplication.Dto
+{
+    public class CategorizeMultipleRequestDto
+    {
+        public List<string> Rows { get; set; } = new List<string>();
+        public List<string> Add { get; set; } = new List<string>();
+        public List<string> Remove { get; set; } = new List<string>();
+    }
+}

--- a/src/JhipsterSampleApplication.Dto/CategorizeRequestDto.cs
+++ b/src/JhipsterSampleApplication.Dto/CategorizeRequestDto.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace JhipsterSampleApplication.Dto
+{
+    public class CategorizeRequestDto
+    {
+        public List<string> Ids { get; set; } = new List<string>();
+        public string Category { get; set; } = string.Empty;
+        public bool RemoveCategory { get; set; }
+    }
+}

--- a/src/JhipsterSampleApplication.Dto/ClusterHealthDto.cs
+++ b/src/JhipsterSampleApplication.Dto/ClusterHealthDto.cs
@@ -1,0 +1,11 @@
+namespace JhipsterSampleApplication.Dto
+{
+    public class ClusterHealthDto
+    {
+        public string Status { get; set; } = string.Empty;
+        public int NumberOfNodes { get; set; }
+        public int NumberOfDataNodes { get; set; }
+        public int ActiveShards { get; set; }
+        public int ActivePrimaryShards { get; set; }
+    }
+}

--- a/src/JhipsterSampleApplication.Dto/SimpleApiResponse.cs
+++ b/src/JhipsterSampleApplication.Dto/SimpleApiResponse.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace JhipsterSampleApplication.Dto
+{
+    public class SimpleApiResponse
+    {
+        public bool Success { get; set; }
+        public string? Message { get; set; }
+    }
+}

--- a/src/JhipsterSampleApplication.Dto/SupremeCreateUpdateDto.cs
+++ b/src/JhipsterSampleApplication.Dto/SupremeCreateUpdateDto.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+
+namespace JhipsterSampleApplication.Dto
+{
+    public class SupremeCreateUpdateDto
+    {
+        public string? Id { get; set; }
+        public string? Name { get; set; }
+        public string? Docket_Number { get; set; }
+        public string? Manner_Of_Jurisdiction { get; set; }
+        public string? Lower_Court { get; set; }
+        public string? Facts_Of_The_Case { get; set; }
+        public string? Question { get; set; }
+        public string? Conclusion { get; set; }
+        public string? Decision { get; set; }
+        public string? Description { get; set; }
+        public string? Dissent { get; set; }
+        public string? Heard_By { get; set; }
+        public string? Term { get; set; }
+        public string? Justia_Url { get; set; }
+        public string? Opinion { get; set; }
+        public string? Argument2_Url { get; set; }
+        public string? Appellant { get; set; }
+        public string? Appellee { get; set; }
+        public string? Petitioner { get; set; }
+        public string? Respondent { get; set; }
+        public List<string>? Recused { get; set; }
+        public List<string>? Majority { get; set; }
+        public List<string>? Minority { get; set; }
+        public List<string>? Advocates { get; set; }
+        public List<string>? Categories { get; set; }
+    }
+}

--- a/src/JhipsterSampleApplication.Dto/SupremeDto.cs
+++ b/src/JhipsterSampleApplication.Dto/SupremeDto.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+
+namespace JhipsterSampleApplication.Dto
+{
+    public class SupremeDto
+    {
+        public string Id { get; set; } = string.Empty;
+        public string? Name { get; set; }
+        public string? Docket_Number { get; set; }
+        public string? Manner_Of_Jurisdiction { get; set; }
+        public string? Lower_Court { get; set; }
+        public string? Facts_Of_The_Case { get; set; }
+        public string? Question { get; set; }
+        public string? Conclusion { get; set; }
+        public string? Decision { get; set; }
+        public string? Description { get; set; }
+        public string? Dissent { get; set; }
+        public string? Heard_By { get; set; }
+        public string? Term { get; set; }
+        public string? Justia_Url { get; set; }
+        public string? Opinion { get; set; }
+        public string? Argument2_Url { get; set; }
+        public string? Appellant { get; set; }
+        public string? Appellee { get; set; }
+        public string? Petitioner { get; set; }
+        public string? Respondent { get; set; }
+        public List<string>? Recused { get; set; }
+        public List<string>? Majority { get; set; }
+        public List<string>? Minority { get; set; }
+        public List<string>? Advocates { get; set; }
+        public List<string> Categories { get; set; } = new List<string>();
+    }
+}

--- a/src/JhipsterSampleApplication/Controllers/BirthdaysController.cs
+++ b/src/JhipsterSampleApplication/Controllers/BirthdaysController.cs
@@ -46,20 +46,6 @@ namespace JhipsterSampleApplication.Controllers
             _viewService = viewService ?? throw new ArgumentNullException(nameof(viewService));
         }
 
-        public class ClusterHealthDto
-        {
-            public string Status { get; set; } = string.Empty;
-            public int NumberOfNodes { get; set; }
-            public int NumberOfDataNodes { get; set; }
-            public int ActiveShards { get; set; }
-            public int ActivePrimaryShards { get; set; }
-        }
-        public class SimpleApiResponse
-        {
-            public bool Success { get; set; }
-            public string? Message { get; set; }
-        }
-
         public class RawSearchRequestDto
         {
             public string? Query { get; set; }
@@ -71,20 +57,6 @@ namespace JhipsterSampleApplication.Controllers
         public class BqlQueryDto
         {
             public string Query { get; set; } = string.Empty;
-        }
-
-        public class CategorizeRequestDto
-        {
-            public List<string> Ids { get; set; } = new List<string>();
-            public string Category { get; set; } = string.Empty;
-            public bool RemoveCategory { get; set; }
-        }
-
-        public class CategorizeMultipleRequestDto
-        {
-            public List<string> Rows { get; set; } = new List<string>();
-            public List<string> Add { get; set; } = new List<string>();
-            public List<string> Remove { get; set; } = new List<string>();
         }
 
         /// <summary>

--- a/supreme.elasticsearch.json
+++ b/supreme.elasticsearch.json
@@ -107,6 +107,15 @@
                     },
                     "term": {
                         "type": "text"
+                    },
+                    "categories": {
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add category support to Supreme domain and index mapping
- expand SupremesController with CRUD, HTML, BQL conversions, health and categorization endpoints
- factor common API response and categorization DTOs for reuse

## Testing
- `dotnet test` *(fails: Expected addResp.StatusCode to be HttpStatusCode.OK {value: 200}, but found HttpStatusCode.InternalServerError {value: 500}.)*

------
https://chatgpt.com/codex/tasks/task_e_689f783d40e48321b6b07dfe786d5d6f