### PR TITLE
Retry ES searches without direct streaming for clearer errors

### DIFF
--- a/src/JhipsterSampleApplication.Domain.Services/BirthdayService.cs
+++ b/src/JhipsterSampleApplication.Domain.Services/BirthdayService.cs
@@ -65,8 +65,11 @@ public class BirthdayService : IBirthdayService
             request.PointInTime = new PointInTime(pitId);
         }
         var response = await _elasticClient.SearchAsync<Birthday>(request);
-        if (!response.IsValid){
-            throw new Exception(response.DebugInformation);
+        if (!response.IsValid)
+        {
+            // Retry with direct streaming disabled to expose detailed error information
+            var retryResponse = await _elasticClient.LowLevel.SearchAsync<StringResponse>(IndexName, PostData.Serializable(request), new SearchRequestParameters { RequestConfiguration = new RequestConfiguration { DisableDirectStreaming = true } });
+            throw new Exception(retryResponse.Body);
         }
         if (response.Hits.Count > 0)
         {


### PR DESCRIPTION
## Summary
- surface Elasticsearch errors by retrying searches with direct streaming disabled in `BirthdayService`
- add same retry logic to `SupremeService`

## Testing
- `dotnet build`
- `dotnet test` *(fails: JhipsterSampleApplication.Test.Controllers.BirthdaysControllerIntTest.*)*

------
https://chatgpt.com/codex/tasks/task_e_689fbb5db60c8321ab819b19685715b9