### PR TITLE
Enable unique term aggregation in Supreme index

### DIFF
--- a/supreme.elasticsearch.json
+++ b/supreme.elasticsearch.json
@@ -106,7 +106,13 @@
                         "type": "text"
                     },
                     "term": {
-                        "type": "text"
+                        "type": "text",
+                        "fields": {
+                            "keyword": {
+                                "type": "keyword",
+                                "ignore_above": 256
+                            }
+                        }
                     },
                     "categories": {
                         "type": "text",


### PR DESCRIPTION
## Summary
- add keyword subfield to `term` in Supreme index mapping so unique-value API works

## Testing
- `dotnet test` *(fails: Expected addResp.StatusCode to be HttpStatusCode.OK {value: 200}, but found HttpStatusCode.InternalServerError {value: 500})*


------
https://chatgpt.com/codex/tasks/task_e_68a487b1aefc8321b9ca6bbf80837513