### PR TITLE
Decouple view identifier from friendly name

### DIFF
--- a/src/JhipsterSampleApplication.Domain.Services/ViewService.cs
+++ b/src/JhipsterSampleApplication.Domain.Services/ViewService.cs
@@ -73,7 +73,7 @@ namespace JhipsterSampleApplication.Domain.Services
             }
 
             var view = _mapper.Map<View>(viewDto);
-            view.SetIdFromName();
+            view.EnsureId();
             var createdView = await _viewRepository.AddAsync(view);
             return _mapper.Map<ViewDto>(createdView);
         }
@@ -96,7 +96,7 @@ namespace JhipsterSampleApplication.Domain.Services
             }
 
             var view = _mapper.Map<View>(viewDto);
-            view.SetIdFromName();
+            view.EnsureId();
             var updatedView = await _viewRepository.UpdateAsync(view);
             return _mapper.Map<ViewDto>(updatedView);
         }

--- a/src/JhipsterSampleApplication.Domain/Entities/View.cs
+++ b/src/JhipsterSampleApplication.Domain/Entities/View.cs
@@ -39,8 +39,15 @@ namespace JhipsterSampleApplication.Domain.Entities
         [Column("domain")]
         public string Domain { get; set; } = string.Empty;
 
-        public void SetIdFromName()
+        public void EnsureId()
         {
+            if (!string.IsNullOrEmpty(Id))
+            {
+                // An explicit identifier was provided. Keep it so renaming the view
+                // doesn't break references or hierarchy relationships.
+                return;
+            }
+
             if (string.IsNullOrEmpty(Name))
             {
                 throw new InvalidOperationException("View name cannot be null or empty");
@@ -48,7 +55,7 @@ namespace JhipsterSampleApplication.Domain.Entities
 
             if (!string.IsNullOrEmpty(parentViewId))
             {
-                Id = $"{parentViewId.ToLowerInvariant()}.{Name.ToLowerInvariant()}";
+                Id = $"{parentViewId.ToLowerInvariant()}/{Name.ToLowerInvariant()}";
             }
             else
             {

--- a/src/JhipsterSampleApplication/Resources/Views/SupremeViews.json
+++ b/src/JhipsterSampleApplication/Resources/Views/SupremeViews.json
@@ -1,7 +1,7 @@
 [
 	{
-		"id": "term",
-		"name": "Term",
+		"id": "heard_term",
+		"name": "Term/heard by",
 		"field": "term",
 		"aggregation": "term.keyword",
 		"query": "term:*",
@@ -17,7 +17,7 @@
 		"query": "heard_by:*",
 		"categoryQuery": "",
 		"script": "",
-		"parentViewId": "term",
+		"parentViewId": "heard_term",
 		"domain": "supreme"
 	},
 	{
@@ -41,6 +41,16 @@
 		"domain": "supreme"
 	},
 	{
+		"id": "decision_term",
+		"name": "Term/decision",
+		"field": "term",
+		"aggregation": "term.keyword",
+		"query": "term:*",
+		"categoryQuery": "",
+		"script": "",
+		"domain": "supreme"
+	},	
+	{
 		"id": "decision",
 		"name": "Decision",
 		"field": "decision",
@@ -48,7 +58,17 @@
 		"query": "decision:*",
 		"categoryQuery": "",
 		"script": "",
+		"parentViewId": "decision_term",
+		"domain": "supreme"
+	},
+	{
+		"id": "term",
+		"name": "Term",
+		"field": "term",
+		"aggregation": "term.keyword",
+		"query": "term:*",
+		"categoryQuery": "",
+		"script": "",
 		"domain": "supreme"
 	}
-
 ]

--- a/test/JhipsterSampleApplication.Test/Domain/ViewEntityTest.cs
+++ b/test/JhipsterSampleApplication.Test/Domain/ViewEntityTest.cs
@@ -1,0 +1,38 @@
+using JhipsterSampleApplication.Domain.Entities;
+using Xunit;
+
+namespace JhipsterSampleApplication.Test.Domain;
+
+public class ViewEntityTest
+{
+    [Fact]
+    public void EnsureId_DoesNotOverwriteProvidedId()
+    {
+        var view = new View
+        {
+            Id = "term",
+            Name = "Term/heard by",
+            Domain = "supreme"
+        };
+
+        view.EnsureId();
+
+        Assert.Equal("term", view.Id);
+    }
+
+    [Fact]
+    public void EnsureId_GeneratesHierarchicalIdWhenMissing()
+    {
+        var view = new View
+        {
+            Name = "Heard By",
+            parentViewId = "term",
+            Domain = "supreme"
+        };
+
+        view.EnsureId();
+
+        Assert.Equal("term/heard by", view.Id);
+    }
+}
+


### PR DESCRIPTION
## Summary
- keep explicitly provided view IDs instead of deriving them from names
- generate hierarchical IDs only when missing
- cover view ID behavior with new tests

## Testing
- `~/dotnet9/dotnet test --no-restore` *(fails: JhipsterSampleApplication.Test.Controllers.BirthdaysControllerIntTest.TestBqlOperations, JhipsterSampleApplication.Test.Controllers.BirthdaysControllerIntTest.TestViewOperations, JhipsterSampleApplication.Test.Controllers.BirthdaysControllerIntTest.TestUncategorizedFirstNameView, JhipsterSampleApplication.Test.Controllers.BirthdaysControllerIntTest.TestCreateAndGetBirthday, JhipsterSampleApplication.Test.Controllers.BirthdaysControllerIntTest.TestComplexBqlOperations, JhipsterSampleApplication.Test.Controllers.BirthdaysControllerIntTest.TestCategorizeMultiple)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ee2b186c8321a3aa89e49c8c6aef