### PR TITLE
feat: add supreme detail iframe

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/supreme/list/supreme.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/supreme/list/supreme.component.html
@@ -96,19 +96,24 @@
       [contextMenu]="contextMenu"
       (onContextMenuSelect)="onContextMenuSelect($event)"
       (contextMenuSelectionChange)="onContextMenuSelect($event)"
+      (rowExpand)="onRowExpand($event)"
+      (rowCollapse)="onRowCollapse($event)"
       [expandedRowTemplate]="expandedRow"
     ></super-table>
   </div>
 
   <ng-template #expandedRow let-rowData>
-    <tr>
-      <td [attr.colspan]="columns.length + 1">
-        <h5>Details for {{ rowData.name }}</h5>
-        <p>Term: {{ rowData.term }}</p>
-        <p>Docket #: {{ rowData.docket_number }}</p>
-        <p>Heard by: {{ rowData.heard_by }}</p>
-      </td>
-    </tr>
+    <ng-container *ngIf="iframeSafeSrcById[rowData.id]; else waiting">
+      <iframe
+        [src]="iframeSafeSrcById[rowData.id]"
+        style="width: 100%; height: 288px; border: 0"
+        (load)="onExpandedIframeLoad(rowData.id, $event)"
+        loading="lazy"
+      ></iframe>
+    </ng-container>
+    <ng-template #waiting>
+      <div class="text-muted" style="padding: 0.5rem 0">Loading…</div>
+    </ng-template>
   </ng-template>
 
   <p-contextMenu #contextMenu [model]="menuItems" (onShow)="onMenuShow()"></p-contextMenu>


### PR DESCRIPTION
## Summary
- load supreme details in expandable iframe with query term highlighting
- serve formatted HTML for Supreme cases

## Testing
- `npm test --prefix src/JhipsterSampleApplication/ClientApp` (fails: <button> should have content and prettier errors)
- `dotnet test` (fails: Birthday controller integration tests)


------
https://chatgpt.com/codex/tasks/task_e_68a4f8287e348321b00925780cda9f72