### PR TITLE
fix: prevent horizontal scroll in Supreme table

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/supreme/list/supreme.component.scss
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/supreme/list/supreme.component.scss
@@ -171,6 +171,7 @@
   /* Ensure scrollable tables don't exceed container width */
   ::ng-deep .p-datatable.p-datatable-scrollable .p-datatable-wrapper {
     overflow: auto;
+    scrollbar-gutter: stable;
   }
 
   /* Match Birthday query builder sizing */


### PR DESCRIPTION
## Summary
- ensure Supreme table reserves space for vertical scrollbar to avoid horizontal overflow

## Testing
- `npm test` *(fails: @angular-eslint/template/elements-content etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a506924c608321baf6c3ad91e442c1