### PR TITLE
fix: prevent horizontal scroll in Supreme table

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/supreme/list/supreme.component.scss
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/supreme/list/supreme.component.scss
@@ -1,9 +1,4 @@
 :host {
-  /* Avoid forcing table/wrapper widths to prevent horizontal scrolling */
-  ::ng-deep .p-datatable table {
-    table-layout: fixed !important;
-    width: 100% !important;
-  }
   ::ng-deep .p-datatable .p-datatable-tbody > tr {
     min-height: 22px !important;
     line-height: 22px !important;
@@ -171,6 +166,11 @@
   /* Ensure scrollable tables don't exceed container width */
   ::ng-deep .p-datatable.p-datatable-scrollable .p-datatable-wrapper {
     overflow: auto;
+  }
+
+  super-table.grid-table {
+    display: block;
+    height: 100%;
   }
 
   /* Match Birthday query builder sizing */


### PR DESCRIPTION
## Summary
- align Supreme table styles with Birthday component to avoid extra horizontal scrollbar
- ensure nested super-table uses block layout and inherits height

## Testing
- `npm test` *(fails: 125 lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a509e691e8832184b5480f148fbbc9