### PR TITLE
Fix PIT pagination for Supreme search

### DIFF
--- a/src/JhipsterSampleApplication/Controllers/SupremesController.cs
+++ b/src/JhipsterSampleApplication/Controllers/SupremesController.cs
@@ -342,19 +342,25 @@ namespace JhipsterSampleApplication.Controllers
 				}
 			}
 
-			var searchRequest = new SearchRequest<Supreme>
-			{
-				Size = pageSize,
-				From = from,
-				Source = includeDescriptive
-					? null
-					: new SourceFilter
-					{
-						Excludes = new[] { "justia_url", "facts_of_the_case", "question", "conclusion" }
-					}
-			};
+                        var searchRequest = new SearchRequest<Supreme>
+                        {
+                                Size = pageSize,
+                                From = from,
+                                Source = includeDescriptive
+                                        ? null
+                                        : new SourceFilter
+                                        {
+                                                Excludes = new[] { "justia_url", "facts_of_the_case", "question", "conclusion" }
+                                        }
+                        };
 
-			var sortDescriptor = new List<ISort>();
+                        if (searchAfter != null && searchAfter.Length > 0)
+                        {
+                                searchRequest.SearchAfter = searchAfter.Cast<object>().ToList();
+                                searchRequest.From = null;
+                        }
+
+                        var sortDescriptor = new List<ISort>();
 			if (!string.IsNullOrEmpty(sort))
 			{
 				var sortParts = sort.Contains(':') ? sort.Split(':') : (sort.Contains(',') ? sort.Split(',') : Array.Empty<string>());


### PR DESCRIPTION
## Summary
- handle `searchAfter` in SupremesController to advance PIT searches

## Testing
- `DOTNET_USE_POLLING_FILE_WATCHER=1 dotnet test --no-build --logger "console;verbosity=normal"`
- `npm test --silent` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a64c6ac4a083218e443e5a4597c496