### PR TITLE
Display Oyez link alongside Justia in Supreme detail

### DIFF
--- a/src/JhipsterSampleApplication/Controllers/SupremesController.cs
+++ b/src/JhipsterSampleApplication/Controllers/SupremesController.cs
@@ -146,8 +146,10 @@ namespace JhipsterSampleApplication.Controllers
                         AppendField("conclusion", WebUtility.HtmlEncode(s.Conclusion ?? string.Empty));
                         AppendField("opinion", WebUtility.HtmlEncode(s.Opinion ?? string.Empty));
                         AppendField("dissent", JoinDissent(s.Dissent));
-                        AppendField("justia url", string.IsNullOrWhiteSpace(s.Justia_Url) ? null : "<a href=\"" + WebUtility.HtmlEncode(s.Justia_Url) + "\">" + WebUtility.HtmlEncode(s.Justia_Url) + "</a>");
-                        AppendField("argument2 url", string.IsNullOrWhiteSpace(s.Argument2_Url) ? null : "<a href=\"" + WebUtility.HtmlEncode(s.Argument2_Url) + "\">" + WebUtility.HtmlEncode(s.Argument2_Url) + "</a>");
+                        AppendInlineFields(
+                                ("justia url", string.IsNullOrWhiteSpace(s.Justia_Url) ? null : "<a href=\"" + WebUtility.HtmlEncode(s.Justia_Url) + "\">" + WebUtility.HtmlEncode(s.Justia_Url) + "</a>"),
+                                ("oyez url", string.IsNullOrWhiteSpace(s.Argument2_Url) ? null : "<a href=\"" + WebUtility.HtmlEncode(s.Argument2_Url) + "\">" + WebUtility.HtmlEncode(s.Argument2_Url) + "</a>")
+                        );
                         AppendField("majority", Join(s.Majority));
                         AppendField("minority", Join(s.Minority));
                         AppendField("recused", Join(s.Recused));


### PR DESCRIPTION
## Summary
- Show Oyez URL next to Justia URL in generated Supreme case detail HTML

## Testing
- `dotnet test` *(fails: Expected addResp.StatusCode to be HttpStatusCode.OK {value: 200}, but found HttpStatusCode.InternalServerError {value: 500}.)*
- `npm test` *(fails: 125 problems (125 errors, 0 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a774ed76448321b8b4acd0e814b293