### PR TITLE
Add includeDescriptive support to Supreme BQL search endpoint

### DIFF
--- a/src/JhipsterSampleApplication/Controllers/SupremesController.cs
+++ b/src/JhipsterSampleApplication/Controllers/SupremesController.cs
@@ -487,8 +487,9 @@ namespace JhipsterSampleApplication.Controllers
 			[FromQuery] string? pitId = null,
 			[FromQuery] string[]? searchAfter = null,
 			[FromQuery] string? view = null,
-			[FromQuery] string? category = null,
-			[FromQuery] string? secondaryCategory = null)
+                        [FromQuery] string? category = null,
+                        [FromQuery] string? secondaryCategory = null,
+                        [FromQuery] bool includeDescriptive = false)
 		{
 			if (string.IsNullOrWhiteSpace(bqlQuery))
 			{
@@ -497,7 +498,7 @@ namespace JhipsterSampleApplication.Controllers
                         var rulesetDto = await _bqlService.Bql2Ruleset(bqlQuery.Trim());
                         var ruleset = _mapper.Map<Ruleset>(rulesetDto);
                         var queryObject = await _supremeService.ConvertRulesetToElasticSearch(ruleset);
-                        return await Search(queryObject, pageSize, from, sort, view, category, secondaryCategory, pitId, searchAfter);
+                        return await Search(queryObject, pageSize, from, sort, view, category, secondaryCategory, pitId, searchAfter, includeDescriptive);
                 }
 
 


### PR DESCRIPTION
## Summary
- allow /api/supreme/search/bql to accept `includeDescriptive` flag

## Testing
- `dotnet test` (fails: Expected addResp.StatusCode to be HttpStatusCode.OK)
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68a78035bfb083219c06636b5e0767e9