### PR TITLE
Fix movies cast unique values case and BQL parsing

### DIFF
--- a/src/JhipsterSampleApplication/Resources/query-builder/movie-qb-spec.json
+++ b/src/JhipsterSampleApplication/Resources/query-builder/movie-qb-spec.json
@@ -20,6 +20,11 @@
       "type": "string",
       "operators": ["contains", "!contains", "in", "!in", "exists"]
     },
+    "cast": {
+      "name": "Cast",
+      "type": "string",
+      "operators": ["contains", "!contains", "like", "!like", "in", "!in", "exists"]
+    },
     "country": {
       "name": "Country",
       "type": "string",


### PR DESCRIPTION
## Summary
- preserve original casing for movie field unique values using top hits
- allow BQL parsing on `cast` field

## Testing
- `dotnet test` *(fails: Expected response.StatusCode to be HttpStatusCode.Unauthorized {value: 401}, but found HttpStatusCode.InternalServerError {value: 500}.)*


------
https://chatgpt.com/codex/tasks/task_e_68aaa27bf39883218b16fa9626a74ad4