### PR TITLE
Fix movie numeric mapping fields

### DIFF
--- a/src/JhipsterSampleApplication.Domain/Entities/Movie.cs
+++ b/src/JhipsterSampleApplication.Domain/Entities/Movie.cs
@@ -18,9 +18,9 @@ namespace JhipsterSampleApplication.Domain.Entities
         public List<string>? Producers { get; set; }
         public List<string>? Writers { get; set; }
         public List<string>? Cast { get; set; }
-        [PropertyName("budget_usd")] public double? BudgetUsd { get; set; }
-        [PropertyName("gross_usd")] public double? GrossUsd { get; set; }
-        [PropertyName("rotten_tomatoes_scores")] public double? RottenTomatoesScores { get; set; }
+        [PropertyName("budget_usd")] public long? BudgetUsd { get; set; }
+        [PropertyName("gross_usd")] public long? GrossUsd { get; set; }
+        [PropertyName("rotten_tomatoes_score")] public int? RottenTomatoesScore { get; set; }
         public string? Summary { get; set; }
         public string? Synopsis { get; set; }
         [PropertyName("categories")] public List<string> Categories { get; set; } = new List<string>();

--- a/src/JhipsterSampleApplication.Dto/MovieCreateUpdateDto.cs
+++ b/src/JhipsterSampleApplication.Dto/MovieCreateUpdateDto.cs
@@ -15,9 +15,9 @@ namespace JhipsterSampleApplication.Dto
         public List<string>? Producers { get; set; }
         public List<string>? Writers { get; set; }
         public List<string>? Cast { get; set; }
-        public double? BudgetUsd { get; set; }
-        public double? GrossUsd { get; set; }
-        public double? RottenTomatoesScores { get; set; }
+        public long? BudgetUsd { get; set; }
+        public long? GrossUsd { get; set; }
+        public int? RottenTomatoesScore { get; set; }
         public string? Summary { get; set; }
         public string? Synopsis { get; set; }
         public List<string>? Categories { get; set; }

--- a/src/JhipsterSampleApplication.Dto/MovieDto.cs
+++ b/src/JhipsterSampleApplication.Dto/MovieDto.cs
@@ -15,9 +15,9 @@ namespace JhipsterSampleApplication.Dto
         public List<string>? Producers { get; set; }
         public List<string>? Writers { get; set; }
         public List<string>? Cast { get; set; }
-        public double? BudgetUsd { get; set; }
-        public double? GrossUsd { get; set; }
-        public double? RottenTomatoesScores { get; set; }
+        public long? BudgetUsd { get; set; }
+        public long? GrossUsd { get; set; }
+        public int? RottenTomatoesScore { get; set; }
         public string? Summary { get; set; }
         public string? Synopsis { get; set; }
         public List<string>? Categories { get; set; }

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/movie/list/movie.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/movie/list/movie.component.ts
@@ -102,7 +102,7 @@ export class MovieComponent implements OnInit, AfterViewInit {
     { field: 'languages', header: 'Languages', filterType: 'text', type: 'string', width: '8rem' },
     { field: 'budget_usd', header: 'Budget', filterType: 'numeric', type: 'string', width: '8rem' },
     { field: 'gross_usd', header: 'Gross', filterType: 'numeric', type: 'string', width: '8rem' },
-    { field: 'rotten_tomatoes_scores', header: 'Rotten Tomatoes', filterType: 'numeric', type: 'string', width: '8rem' },
+    { field: 'rotten_tomatoes_score', header: 'Rotten Tomatoes', filterType: 'numeric', type: 'string', width: '8rem' },
   ];
 
   private lastSortEvent: any = null;

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/movie/movie.model.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/movie/movie.model.ts
@@ -8,7 +8,7 @@ export interface IMovie {
   languages?: string[];
   budget_usd?: number;
   gross_usd?: number;
-  rotten_tomatoes_scores?: number;
+  rotten_tomatoes_score?: number;
 }
 
 export class Movie implements IMovie {
@@ -22,7 +22,7 @@ export class Movie implements IMovie {
     public languages?: string[],
     public budget_usd?: number,
     public gross_usd?: number,
-    public rotten_tomatoes_scores?: number,
+    public rotten_tomatoes_score?: number,
   ) {}
 }
 

--- a/src/JhipsterSampleApplication/Controllers/MoviesController.cs
+++ b/src/JhipsterSampleApplication/Controllers/MoviesController.cs
@@ -79,7 +79,7 @@ namespace JhipsterSampleApplication.Controllers
             AppendField("Cast", m.Cast == null ? null : string.Join(", ", m.Cast));
             AppendField("Budget", m.BudgetUsd?.ToString());
             AppendField("Gross", m.GrossUsd?.ToString());
-            AppendField("Rotten Tomatoes", m.RottenTomatoesScores?.ToString());
+            AppendField("Rotten Tomatoes", m.RottenTomatoesScore?.ToString());
             AppendField("Summary", m.Summary);
             AppendField("Synopsis", m.Synopsis);
             sb.Append("</body></html>");

--- a/src/JhipsterSampleApplication/Controllers/MoviesController.cs
+++ b/src/JhipsterSampleApplication/Controllers/MoviesController.cs
@@ -116,7 +116,7 @@ namespace JhipsterSampleApplication.Controllers
             }
             JObject queryStringObject = new JObject(new JProperty("query", query));
             JObject queryObject = new JObject(new JProperty("query_string", queryStringObject));
-            var overrideSort = "release_year.keyword:desc";
+            var overrideSort = "release_year:desc";
             return await Search(queryObject, pageSize, from, overrideSort, includeDescriptive, pitId, searchAfter);
         }
 


### PR DESCRIPTION
## Summary
- rename rotten tomatoes score field and correct numeric types on movie DTO
- align Angular model and grid column with updated field name

## Testing
- `dotnet test` *(fails: MSB4017 unexpected logger failure)*
- `npm test` *(fails: Prettier found 137 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acbb7361808321944479f62c10bf68