### PR TITLE
feat(movie): add html expander

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/movie/list/movie.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/movie/list/movie.component.ts
@@ -103,6 +103,7 @@ export class MovieComponent implements OnInit, AfterViewInit {
     { field: 'budgetUsd', header: 'Budget', filterType: 'numeric', type: 'string', width: '8rem' },
     { field: 'grossUsd', header: 'Gross', filterType: 'numeric', type: 'string', width: '8rem' },
     { field: 'rottenTomatoesScore', header: 'Rotten Tomatoes', filterType: 'numeric', type: 'string', width: '8rem' },
+    { field: 'expander', header: '', type: 'expander', width: '25px', style: 'font-weight: 700;' },
   ];
 
   private lastSortEvent: any = null;
@@ -215,7 +216,7 @@ export class MovieComponent implements OnInit, AfterViewInit {
     const key = (row as any)?.id || JSON.stringify(row);
     this.expandedRowKeys[key] = true;
     setTimeout(() => {
-      const url = '/api/movie/html/' + (row as any).id;
+      const url = '/api/movies/html/' + (row as any).id;
       this.iframeSafeSrcById[(row as any).id!] = this.sanitizer.bypassSecurityTrustResourceUrl(url);
     }, 50);
   }

--- a/src/JhipsterSampleApplication/Controllers/MoviesController.cs
+++ b/src/JhipsterSampleApplication/Controllers/MoviesController.cs
@@ -58,32 +58,49 @@ namespace JhipsterSampleApplication.Controllers
             {
                 return NotFound();
             }
+
             var m = response.Documents.First();
+
+            string? Join(IEnumerable<string>? list)
+            {
+                if (list == null) return null;
+                var vals = list.Where(v => !string.IsNullOrWhiteSpace(v)).Select(v => WebUtility.HtmlEncode(v.Trim())).ToList();
+                return vals.Count > 0 ? string.Join(", ", vals) : null;
+            }
+
+            string? Encode(string? v) => string.IsNullOrWhiteSpace(v) ? null : WebUtility.HtmlEncode(v);
+
             var sb = new StringBuilder();
-            sb.Append("<!doctype html><html><head><meta charset=\"utf-8\"><title>")
+            sb.Append("<!doctype html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><base target=\"_blank\"><title>")
               .Append(WebUtility.HtmlEncode(m.Title ?? "Movie"))
-              .Append("</title></head><body>");
+              .Append("</title><style>body{margin:0;padding:8px;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,Helvetica Neue,Arial,\"Apple Color Emoji\",\"Segoe UI Emoji\";font-size:14px;line-height:1.4;color:#111}.field-name{font-weight:600}.field{margin-bottom:0.7em}</style></head><body>");
+
             void AppendField(string label, string? value)
             {
                 if (string.IsNullOrWhiteSpace(value)) return;
-                sb.Append("<div><strong>").Append(WebUtility.HtmlEncode(label)).Append(":</strong> ")
-                  .Append(WebUtility.HtmlEncode(value)).Append("</div>");
+                sb.Append("<div class=\"field\"><span class=\"field-name\">")
+                  .Append(WebUtility.HtmlEncode(label))
+                  .Append(":</span> ")
+                  .Append(value)
+                  .Append("</div>");
             }
-            AppendField("Title", m.Title);
-            AppendField("Release Year", m.ReleaseYear?.ToString());
-            AppendField("Genres", m.Genres == null ? null : string.Join(", ", m.Genres));
-            AppendField("Runtime", m.RuntimeMinutes?.ToString());
-            AppendField("Country", m.Country);
-            AppendField("Languages", m.Languages == null ? null : string.Join(", ", m.Languages));
-            AppendField("Directors", m.Directors == null ? null : string.Join(", ", m.Directors));
-            AppendField("Producers", m.Producers == null ? null : string.Join(", ", m.Producers));
-            AppendField("Writers", m.Writers == null ? null : string.Join(", ", m.Writers));
-            AppendField("Cast", m.Cast == null ? null : string.Join(", ", m.Cast));
-            AppendField("Budget", m.BudgetUsd?.ToString());
-            AppendField("Gross", m.GrossUsd?.ToString());
-            AppendField("Rotten Tomatoes", m.RottenTomatoesScore?.ToString());
-            AppendField("Summary", m.Summary);
-            AppendField("Synopsis", m.Synopsis);
+
+            AppendField("Title", Encode(m.Title));
+            AppendField("Release Year", Encode(m.ReleaseYear?.ToString()));
+            AppendField("Genres", Join(m.Genres));
+            AppendField("Runtime", Encode(m.RuntimeMinutes?.ToString()));
+            AppendField("Country", Encode(m.Country));
+            AppendField("Languages", Join(m.Languages));
+            AppendField("Directors", Join(m.Directors));
+            AppendField("Producers", Join(m.Producers));
+            AppendField("Writers", Join(m.Writers));
+            AppendField("Cast", Join(m.Cast));
+            AppendField("Budget", Encode(m.BudgetUsd?.ToString()));
+            AppendField("Gross", Encode(m.GrossUsd?.ToString()));
+            AppendField("Rotten Tomatoes", Encode(m.RottenTomatoesScore?.ToString()));
+            AppendField("Summary", Encode(m.Summary));
+            AppendField("Synopsis", Encode(m.Synopsis));
+
             sb.Append("</body></html>");
             return Content(sb.ToString(), "text/html");
         }


### PR DESCRIPTION
## Summary
- add expander column to movie grid and load HTML detail from API
- render movie HTML pages with bold labels and synopsis

## Testing
- `npm test` *(fails: prettier/prettier errors)*
- `dotnet test` *(fails: 6 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68addcb5a740832185b5bc4b9127e93e