### PR TITLE
fix: wire named query domain to builders

### DIFF
--- a/src/JhipsterSampleApplication.Domain.Services/NamedQueryService.cs
+++ b/src/JhipsterSampleApplication.Domain.Services/NamedQueryService.cs
@@ -48,12 +48,12 @@ namespace JhipsterSampleApplication.Domain.Services
                     namedQuery.IsSystem = null;
                     namedQuery.Owner = string.IsNullOrEmpty(namedQuery.Owner) ? (currentUser?.Login ?? namedQuery.Owner) : namedQuery.Owner;
                 }
-                NamedQuery? existing = await FindByNameAndOwner(namedQuery.Name, namedQuery.Owner.Replace("SYSTEM", "GLOBAL"), namedQuery.Domain);
-                if (existing != null && existing.Id != namedQuery.Id && existing.Owner.Replace("SYSTEM", "GLOBAL") == namedQuery.Owner.Replace("SYSTEM", "GLOBAL"))
+                NamedQuery? existing = await FindByNameAndOwner(namedQuery.Name, namedQuery.Owner!.Replace("SYSTEM", "GLOBAL"), namedQuery.Domain);
+                if (existing != null && existing.Id != namedQuery.Id && existing.Owner!.Replace("SYSTEM", "GLOBAL") == namedQuery.Owner.Replace("SYSTEM", "GLOBAL"))
                 {
                     throw new InvalidOperationException("A query by that name already exists");
                 }
-                if (existing != null && existing.Owner.Replace("SYSTEM","GLOBAL") != namedQuery.Owner.Replace("SYSTEM", "GLOBAL"))
+                if (existing != null && existing.Owner!.Replace("SYSTEM","GLOBAL") != namedQuery.Owner.Replace("SYSTEM", "GLOBAL"))
                 {
                     namedQuery.Id = 0; // force insert
                 }

--- a/src/JhipsterSampleApplication.Domain/Entities/NamedQuery.cs
+++ b/src/JhipsterSampleApplication.Domain/Entities/NamedQuery.cs
@@ -18,7 +18,7 @@ namespace JhipsterSampleApplication.Domain.Entities
 
         [Required]
         [StringLength(50)]
-        public required string Owner { get; set; }
+        public string? Owner { get; set; }
 
         [Required]
         [StringLength(50)]

--- a/src/JhipsterSampleApplication.Dto/NamedQueryDto.cs
+++ b/src/JhipsterSampleApplication.Dto/NamedQueryDto.cs
@@ -12,7 +12,7 @@ namespace JhipsterSampleApplication.Dto
         [Required]
         public required string Text { get; set; }
 
-        public required string Owner { get; set; }
+        public string? Owner { get; set; }
 
         [Required]
         public required string Domain { get; set; }

--- a/src/JhipsterSampleApplication.Infrastructure/Data/Repositories/UnitOfWork.cs
+++ b/src/JhipsterSampleApplication.Infrastructure/Data/Repositories/UnitOfWork.cs
@@ -75,7 +75,7 @@ public class UnitOfWork : IUnitOfWork
                 throw;
             }
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             // Catch any other exceptions and rethrow them.
             throw;

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
@@ -6,7 +6,7 @@
       (queryChange)="onQueryChange($event)"
       placeholder="click search icon for widget or click to edit"
       [spec]="spec"
-      [namedQueryDomain]="'birthdays'"
+      [namedQueryDomain]="'birthday'"
     >
     </lib-query-input>
     <div class="d-flex ms-auto">

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/movie/list/movie.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/movie/list/movie.component.html
@@ -6,6 +6,7 @@
       (queryChange)="onQueryChange($event)"
       placeholder="click search icon for widget or click to edit"
       [spec]="spec"
+      [namedQueryDomain]="'movie'"
     ></lib-query-input>
 
     <div class="d-flex ms-auto">

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/supreme/list/supreme.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/supreme/list/supreme.component.html
@@ -6,6 +6,7 @@
       (queryChange)="onQueryChange($event)"
       placeholder="click search icon for widget or click to edit"
       [spec]="spec"
+      [namedQueryDomain]="'supreme'"
     ></lib-query-input>
 
     <div class="d-flex ms-auto">


### PR DESCRIPTION
## Summary
- align birthday builder with correct named query domain
- scope supreme and movie builders to their own domains

## Testing
- `dotnet test` *(fails: Failed: 6, Passed: 75)*
- `npm test` *(fails: Parsing error in prettier)*

------
https://chatgpt.com/codex/tasks/task_e_68af5d62c9108321a7e2cf7d01b1dd86