### PR TITLE
feat: enable case-insensitive equality in BQL

### DIFF
--- a/src/JhipsterSampleApplication.Domain.Services/GenericBqlService.cs
+++ b/src/JhipsterSampleApplication.Domain.Services/GenericBqlService.cs
@@ -245,13 +245,63 @@ namespace JhipsterSampleApplication.Domain.Services
                         return BuildDateQuery(ruleset.field!, "=", valueStr);
                     }
 
+                    var valueLower = valueStr.ToLowerInvariant();
+
                     ret = new JObject
                     {
                         {
-                            "term",
+                            "bool",
                             new JObject
                             {
-                                { ruleset.field + ".keyword", valueStr }
+                                {
+                                    "must",
+                                    new JArray
+                                    {
+                                        new JObject
+                                        {
+                                            {
+                                                "match",
+                                                new JObject
+                                                {
+                                                    {
+                                                        ruleset.field!,
+                                                        new JObject
+                                                        {
+                                                            { "query", valueLower },
+                                                            { "operator", "and" }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        new JObject
+                                        {
+                                            {
+                                                "script",
+                                                new JObject
+                                                {
+                                                    {
+                                                        "script",
+                                                        new JObject
+                                                        {
+                                                            {
+                                                                "source",
+                                                                $"doc['{ruleset.field}.keyword'].value.toLowerCase() == params.query"
+                                                            },
+                                                            {
+                                                                "params",
+                                                                new JObject
+                                                                {
+                                                                    { "query", valueLower }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     };


### PR DESCRIPTION
## Summary
- make '=' operator in BQL case-insensitive by using bool with match and script

## Testing
- `dotnet test` *(fails: Failed: 6, Passed: 75)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a80b1a408321af9a0275a0679f72