### PR TITLE
feat: guard query actions when BQL is invalid

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.html
@@ -14,7 +14,7 @@
       pInputText
       [(ngModel)]="query"
       (ngModelChange)="onQueryChange()"
-      (keyup.enter)="acceptEdit()"
+      (keydown.enter)="onEnter($event)"
       [ngClass]="{ invalid: !validQuery }"
     />
   }
@@ -22,7 +22,11 @@
   @if (editing) {
     <div class="btn-group">
       <i class="pi pi-times action-icon" (click)="cancelEdit()"></i>
-      <i class="pi pi-check action-icon" (click)="acceptEdit()" [ngClass]="{ disabled: !validQuery }"></i>
+      <i
+        class="pi pi-check action-icon"
+        (click)="acceptEdit()"
+        [ngClass]="{ disabled: !validQuery }"
+      ></i>
     </div>
   }
 </div>
@@ -50,6 +54,7 @@
   [baseZIndex]="10000"
 >
   <ngx-query-builder
+    #builder
     [(ngModel)]="builderQuery"
     [config]="queryBuilderConfig"
     [spec]="spec"
@@ -64,7 +69,13 @@
   <ng-template pTemplate="footer">
     <div class="dialog-footer">
       <button pButton label="Cancel" (click)="cancelQuery()" class="p-button-secondary"></button>
-      <button pButton label="Apply" (click)="applyQuery()" class="p-button-primary"></button>
+      <button
+        pButton
+        label="Apply"
+        (click)="applyQuery()"
+        class="p-button-primary"
+        [disabled]="builder?.namingRuleset"
+      ></button>
     </div>
   </ng-template>
 </p-dialog>

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.ts
@@ -1,4 +1,12 @@
-import { Component, EventEmitter, Input, Output, OnInit, inject } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  OnInit,
+  ViewChild,
+  inject,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { HttpClient, HttpParams, HttpClientModule } from '@angular/common/http';
@@ -13,6 +21,7 @@ import {
   RuleSet,
   Rule,
   QueryLanguageSpec,
+  QueryBuilderComponent,
 } from 'ngx-query-builder';
 import {
   bqlToRuleset,
@@ -52,6 +61,8 @@ interface NamedQuery {
 export class QueryInputComponent implements OnInit {
   private dialog = inject(MatDialog);
   private http = inject(HttpClient);
+
+  @ViewChild('builder') builder?: QueryBuilderComponent;
 
   @Input() placeholder = 'BQL';
   @Input() query = '';
@@ -201,9 +212,20 @@ export class QueryInputComponent implements OnInit {
   }
 
   acceptEdit() {
+    if (!this.validQuery) {
+      return;
+    }
     this.editing = false;
     this.previousQuery = this.query;
     this.queryChange.emit(this.query);
+  }
+
+  onEnter(event: KeyboardEvent) {
+    if (this.validQuery) {
+      this.acceptEdit();
+    } else {
+      event.preventDefault();
+    }
   }
 
   parseQuery(text: string): RuleSet {

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/birthday/list/birthday.component.html
@@ -2,6 +2,7 @@
   <h2 id="page-heading" data-cy="BirthdayHeading" class="d-flex align-items-center gap-2">
     <span>Birthdays...</span>
     <lib-query-input
+      #queryInput
       [(query)]="currentQuery"
       (queryChange)="onQueryChange($event)"
       placeholder="click search icon for widget or click to edit"
@@ -14,13 +15,19 @@
         class="btn btn-info me-2"
         (click)="refreshData()"
         [title]="(dataLoader.loading$ | async) ? 'Refresh (cancel current and restart)' : 'Refresh List'"
+        [disabled]="queryInput.editing && !queryInput.validQuery"
       >
         <fa-icon icon="sync" [spin]="dataLoader.loading$ | async"></fa-icon>
         <span>Refresh List</span>
       </button>
 
       <div class="d-flex align-items-center ms-2">
-        <select class="form-select w-auto" [(ngModel)]="viewName" (ngModelChange)="onViewChange($event)">
+        <select
+          class="form-select w-auto"
+          [(ngModel)]="viewName"
+          (ngModelChange)="onViewChange($event)"
+          [disabled]="queryInput.editing && !queryInput.validQuery"
+        >
           <option [ngValue]="null">Select a view</option>
           @for (v of views; track v) {
             <option [ngValue]="v.value">
@@ -29,7 +36,13 @@
           }
         </select>
         @if (viewName) {
-          <button type="button" class="btn btn-link p-0 ms-1" aria-label="Clear selected view" (click)="onViewChange(null)">
+          <button
+            type="button"
+            class="btn btn-link p-0 ms-1"
+            aria-label="Clear selected view"
+            (click)="onViewChange(null)"
+            [disabled]="queryInput.editing && !queryInput.validQuery"
+          >
             <fa-icon icon="times"></fa-icon>
           </button>
         }

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/movie/list/movie.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/movie/list/movie.component.html
@@ -2,6 +2,7 @@
   <h2 class="d-flex align-items-center gap-2">
     <span>Movies...</span>
     <lib-query-input
+      #queryInput
       [(query)]="currentQuery"
       (queryChange)="onQueryChange($event)"
       placeholder="click search icon for widget or click to edit"
@@ -14,13 +15,19 @@
         class="btn btn-info me-2"
         (click)="refreshData()"
         [title]="(dataLoader.loading$ | async) ? 'Refresh (cancel current and restart)' : 'Refresh List'"
+        [disabled]="queryInput.editing && !queryInput.validQuery"
       >
         <fa-icon icon="sync" [spin]="dataLoader.loading$ | async"></fa-icon>
         <span>Refresh List</span>
       </button>
 
       <div class="d-flex align-items-center ms-2">
-        <select class="form-select w-auto" [(ngModel)]="viewName" (ngModelChange)="onViewChange($event)">
+        <select
+          class="form-select w-auto"
+          [(ngModel)]="viewName"
+          (ngModelChange)="onViewChange($event)"
+          [disabled]="queryInput.editing && !queryInput.validQuery"
+        >
           <option [ngValue]="null">Select a view</option>
           @for (v of views; track v) {
             <option [ngValue]="v.value">
@@ -29,7 +36,13 @@
           }
         </select>
         @if (viewName) {
-          <button type="button" class="btn btn-link p-0 ms-1" aria-label="Clear selected view" (click)="onViewChange(null)">
+          <button
+            type="button"
+            class="btn btn-link p-0 ms-1"
+            aria-label="Clear selected view"
+            (click)="onViewChange(null)"
+            [disabled]="queryInput.editing && !queryInput.validQuery"
+          >
             <fa-icon icon="times"></fa-icon>
           </button>
         }

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/supreme/list/supreme.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/supreme/list/supreme.component.html
@@ -2,6 +2,7 @@
   <h2 class="d-flex align-items-center gap-2">
     <span>Supreme...</span>
     <lib-query-input
+      #queryInput
       [(query)]="currentQuery"
       (queryChange)="onQueryChange($event)"
       placeholder="click search icon for widget or click to edit"
@@ -14,13 +15,19 @@
         class="btn btn-info me-2"
         (click)="refreshData()"
         [title]="(dataLoader.loading$ | async) ? 'Refresh (cancel current and restart)' : 'Refresh List'"
+        [disabled]="queryInput.editing && !queryInput.validQuery"
       >
         <fa-icon icon="sync" [spin]="dataLoader.loading$ | async"></fa-icon>
         <span>Refresh List</span>
       </button>
 
       <div class="d-flex align-items-center ms-2">
-        <select class="form-select w-auto" [(ngModel)]="viewName" (ngModelChange)="onViewChange($event)">
+        <select
+          class="form-select w-auto"
+          [(ngModel)]="viewName"
+          (ngModelChange)="onViewChange($event)"
+          [disabled]="queryInput.editing && !queryInput.validQuery"
+        >
           <option [ngValue]="null">Select a view</option>
           @for (v of views; track v) {
             <option [ngValue]="v.value">
@@ -29,7 +36,13 @@
           }
         </select>
         @if (viewName) {
-          <button type="button" class="btn btn-link p-0 ms-1" aria-label="Clear selected view" (click)="onViewChange(null)">
+          <button
+            type="button"
+            class="btn btn-link p-0 ms-1"
+            aria-label="Clear selected view"
+            (click)="onViewChange(null)"
+            [disabled]="queryInput.editing && !queryInput.validQuery"
+          >
             <fa-icon icon="times"></fa-icon>
           </button>
         }


### PR DESCRIPTION
## Summary
- prevent accepting BQL edits when query fails validation
- disable refresh/view controls until BQL is valid
- block query builder Apply while naming a ruleset

## Testing
- `npm test` *(fails: Prettier parsing errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68b0afa4e4b88321a6400fe6c86550a4