### PR TITLE
Fix enter key event typing in query input

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.html
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.html
@@ -14,7 +14,7 @@
       pInputText
       [(ngModel)]="query"
       (ngModelChange)="onQueryChange()"
-      (keydown.enter)="onEnter($event)"
+      (keydown.enter)="onEnter($event as KeyboardEvent)"
       [ngClass]="{ invalid: !validQuery }"
     />
   }


### PR DESCRIPTION
## Summary
- cast `$event` as `KeyboardEvent` for enter key handler to satisfy type checking

## Testing
- `npm test -- --watch=false` *(fails: Parsing error from Prettier)*
- `npx ng test popup-ngx-query-builder --watch=false --browsers=ChromeHeadless` *(fails: Cannot find module 'karma-jasmine')*


------
https://chatgpt.com/codex/tasks/task_e_68b0b2de6b24832186795ffec6194d3f