### PR TITLE
Allow retrieving histories without specifying domain

### DIFF
--- a/src/JhipsterSampleApplication.Domain.Services/HistoryService.cs
+++ b/src/JhipsterSampleApplication.Domain.Services/HistoryService.cs
@@ -22,7 +22,7 @@ namespace JhipsterSampleApplication.Domain.Services
             return history;
         }
 
-        public async Task<IEnumerable<History>> FindByUserAndDomain(string user, string domain)
+        public async Task<IEnumerable<History>> FindByUserAndDomain(string user, string? domain = null)
         {
             return await _historyRepository.FindByUserAndDomain(user, domain);
         }

--- a/src/JhipsterSampleApplication.Domain/Repositories/Interfaces/IHistoryRepository.cs
+++ b/src/JhipsterSampleApplication.Domain/Repositories/Interfaces/IHistoryRepository.cs
@@ -6,6 +6,6 @@ namespace JhipsterSampleApplication.Domain.Repositories.Interfaces
 {
     public interface IHistoryRepository : IGenericRepository<History, long>
     {
-        Task<IEnumerable<History>> FindByUserAndDomain(string user, string domain);
+        Task<IEnumerable<History>> FindByUserAndDomain(string user, string? domain = null);
     }
 }

--- a/src/JhipsterSampleApplication.Domain/Services/Interfaces/IHistoryService.cs
+++ b/src/JhipsterSampleApplication.Domain/Services/Interfaces/IHistoryService.cs
@@ -7,6 +7,6 @@ namespace JhipsterSampleApplication.Domain.Services.Interfaces
     public interface IHistoryService
     {
         Task<History> Save(History history);
-        Task<IEnumerable<History>> FindByUserAndDomain(string user, string domain);
+        Task<IEnumerable<History>> FindByUserAndDomain(string user, string? domain = null);
     }
 }

--- a/src/JhipsterSampleApplication.Infrastructure/Data/Repositories/HistoryRepository.cs
+++ b/src/JhipsterSampleApplication.Infrastructure/Data/Repositories/HistoryRepository.cs
@@ -12,8 +12,16 @@ namespace JhipsterSampleApplication.Infrastructure.Data.Repositories
         {
         }
 
-        public async Task<IEnumerable<History>> FindByUserAndDomain(string user, string domain)
+        public async Task<IEnumerable<History>> FindByUserAndDomain(string user, string? domain = null)
         {
+            if (string.IsNullOrEmpty(domain))
+            {
+                return await QueryHelper()
+                    .Filter(h => h.User == user)
+                    .OrderBy(q => q.OrderByDescending(h => h.Id))
+                    .GetAllAsync();
+            }
+
             return await QueryHelper()
                 .Filter(h => h.User == user && h.Domain == domain)
                 .OrderBy(q => q.OrderByDescending(h => h.Id))

--- a/src/JhipsterSampleApplication/Controllers/HistoriesController.cs
+++ b/src/JhipsterSampleApplication/Controllers/HistoriesController.cs
@@ -26,7 +26,7 @@ namespace JhipsterSampleApplication.Controllers
         }
 
         [HttpGet]
-        public async Task<ActionResult<IEnumerable<HistoryDto>>> GetAll([FromQuery] string domain)
+        public async Task<ActionResult<IEnumerable<HistoryDto>>> GetAll([FromQuery] string? domain = null)
         {
             var user = User?.Identity?.Name;
             if (string.IsNullOrEmpty(user))
@@ -59,7 +59,7 @@ namespace JhipsterSampleApplication.Controllers
             {
                 return Unauthorized();
             }
-            var histories = await _historyService.FindByUserAndDomain(user, string.Empty);
+            var histories = await _historyService.FindByUserAndDomain(user, null);
             var history = histories.FirstOrDefault(h => h.Id == id);
             if (history == null)
             {
@@ -77,7 +77,7 @@ namespace JhipsterSampleApplication.Controllers
             {
                 return Unauthorized();
             }
-            var histories = await _historyService.FindByUserAndDomain(user, string.Empty);
+            var histories = await _historyService.FindByUserAndDomain(user, null);
             var history = histories.FirstOrDefault(h => h.Id == id);
             if (history == null)
             {


### PR DESCRIPTION
## Summary
- make `HistoriesController` accept an optional `domain` query parameter
- support fetching all histories when domain is not provided by updating service and repository APIs

## Testing
- `dotnet test` *(fails: 6, passes: 75)*

------
https://chatgpt.com/codex/tasks/task_e_68b0dd6674d4832186ce737c7ee2e6b4