### PR TITLE
Prevent duplicate BQL history records

### DIFF
--- a/src/JhipsterSampleApplication.Domain.Services/HistoryService.cs
+++ b/src/JhipsterSampleApplication.Domain.Services/HistoryService.cs
@@ -17,6 +17,12 @@ namespace JhipsterSampleApplication.Domain.Services
 
         public async Task<History> Save(History history)
         {
+            var latest = await _historyRepository.FindLatestByUserAndDomain(history.User, history.Domain);
+            if (latest != null && latest.Text == history.Text)
+            {
+                return latest;
+            }
+
             await _historyRepository.CreateOrUpdateAsync(history);
             await _historyRepository.SaveChangesAsync();
             return history;

--- a/src/JhipsterSampleApplication.Domain/Repositories/Interfaces/IHistoryRepository.cs
+++ b/src/JhipsterSampleApplication.Domain/Repositories/Interfaces/IHistoryRepository.cs
@@ -7,5 +7,6 @@ namespace JhipsterSampleApplication.Domain.Repositories.Interfaces
     public interface IHistoryRepository : IGenericRepository<History, long>
     {
         Task<IEnumerable<History>> FindByUserAndDomain(string user, string? domain = null);
+        Task<History?> FindLatestByUserAndDomain(string? user, string? domain = null);
     }
 }

--- a/src/JhipsterSampleApplication.Infrastructure/Data/Repositories/HistoryRepository.cs
+++ b/src/JhipsterSampleApplication.Infrastructure/Data/Repositories/HistoryRepository.cs
@@ -27,5 +27,31 @@ namespace JhipsterSampleApplication.Infrastructure.Data.Repositories
                 .OrderBy(q => q.OrderByDescending(h => h.Id))
                 .GetAllAsync();
         }
+
+        public async Task<History?> FindLatestByUserAndDomain(string? user, string? domain = null)
+        {
+            if (string.IsNullOrEmpty(user))
+            {
+                return null;
+            }
+
+            IEnumerable<History> histories;
+            if (string.IsNullOrEmpty(domain))
+            {
+                histories = await QueryHelper()
+                    .Filter(h => h.User == user)
+                    .OrderBy(q => q.OrderByDescending(h => h.Id))
+                    .GetAllAsync();
+            }
+            else
+            {
+                histories = await QueryHelper()
+                    .Filter(h => h.User == user && h.Domain == domain)
+                    .OrderBy(q => q.OrderByDescending(h => h.Id))
+                    .GetAllAsync();
+            }
+
+            return histories.FirstOrDefault();
+        }
     }
 }

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.ts
@@ -246,6 +246,8 @@ export class QueryInputComponent implements OnInit {
     if (this.historyIndex < this.history.length - 1) {
       this.historyIndex++;
       this.query = this.history[this.historyIndex];
+      this.onQueryChange();
+      this.queryChange.emit(this.query);
     }
   }
 
@@ -257,9 +259,13 @@ export class QueryInputComponent implements OnInit {
     if (this.historyIndex > 0) {
       this.historyIndex--;
       this.query = this.history[this.historyIndex];
+      this.onQueryChange();
+      this.queryChange.emit(this.query);
     } else {
       this.historyIndex = -1;
       this.query = '';
+      this.onQueryChange();
+      this.queryChange.emit(this.query);
     }
   }
 


### PR DESCRIPTION
## Summary
- avoid saving identical history entries back-to-back for a user/domain
- trigger validation when navigating query history in the BQL editor

## Testing
- `dotnet test` *(fails: Expected HttpStatusCode.OK...)*
- `npm test` *(fails: Prettier parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b3868c49348321af827d864591f04d