### PR TITLE
Avoid duplicate history entries and validate recalled queries

### DIFF
--- a/src/JhipsterSampleApplication.Domain.Services/HistoryService.cs
+++ b/src/JhipsterSampleApplication.Domain.Services/HistoryService.cs
@@ -17,6 +17,15 @@ namespace JhipsterSampleApplication.Domain.Services
 
         public async Task<History> Save(History history)
         {
+            if (!string.IsNullOrEmpty(history.User))
+            {
+                var latest = await _historyRepository.FindLatestByUserAndDomain(history.User!, history.Domain);
+                if (latest != null && latest.Text == history.Text)
+                {
+                    return latest;
+                }
+            }
+
             await _historyRepository.CreateOrUpdateAsync(history);
             await _historyRepository.SaveChangesAsync();
             return history;

--- a/src/JhipsterSampleApplication.Domain/Repositories/Interfaces/IHistoryRepository.cs
+++ b/src/JhipsterSampleApplication.Domain/Repositories/Interfaces/IHistoryRepository.cs
@@ -7,5 +7,6 @@ namespace JhipsterSampleApplication.Domain.Repositories.Interfaces
     public interface IHistoryRepository : IGenericRepository<History, long>
     {
         Task<IEnumerable<History>> FindByUserAndDomain(string user, string? domain = null);
+        Task<History?> FindLatestByUserAndDomain(string user, string? domain = null);
     }
 }

--- a/src/JhipsterSampleApplication.Infrastructure/Data/Repositories/HistoryRepository.cs
+++ b/src/JhipsterSampleApplication.Infrastructure/Data/Repositories/HistoryRepository.cs
@@ -27,5 +27,11 @@ namespace JhipsterSampleApplication.Infrastructure.Data.Repositories
                 .OrderBy(q => q.OrderByDescending(h => h.Id))
                 .GetAllAsync();
         }
+
+        public async Task<History?> FindLatestByUserAndDomain(string user, string? domain = null)
+        {
+            var histories = await FindByUserAndDomain(user, domain);
+            return histories.FirstOrDefault();
+        }
     }
 }

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.ts
@@ -224,8 +224,10 @@ export class QueryInputComponent implements OnInit {
     this.previousQuery = this.query;
     this.queryChange.emit(this.query);
     if (this.historyDomain && this.query) {
-      this.http.post('/api/Histories', { domain: this.historyDomain, text: this.query }).subscribe();
-      this.history.unshift(this.query);
+      if (this.history[0] !== this.query) {
+        this.http.post('/api/Histories', { domain: this.historyDomain, text: this.query }).subscribe();
+        this.history.unshift(this.query);
+      }
       this.historyIndex = -1;
     }
   }
@@ -247,6 +249,7 @@ export class QueryInputComponent implements OnInit {
       this.historyIndex++;
       this.query = this.history[this.historyIndex];
     }
+    this.onQueryChange();
   }
 
   showNextHistory(event: any) {
@@ -261,6 +264,7 @@ export class QueryInputComponent implements OnInit {
       this.historyIndex = -1;
       this.query = '';
     }
+    this.onQueryChange();
   }
 
   private loadHistory(): void {


### PR DESCRIPTION
## Summary
- avoid saving duplicate history records by checking latest entry
- skip client history POST for consecutive identical queries
- revalidate and keep editing state when navigating history with arrow keys

## Testing
- `npm test --prefix src/JhipsterSampleApplication/ClientApp` *(fails: Parsing error: Unexpected token)*
- `dotnet test` *(fails: Expected addResp.StatusCode to be HttpStatusCode.OK)*

------
https://chatgpt.com/codex/tasks/task_e_68b38e66a5c48321b2b975068ad8c6e9