### PR TITLE
fix(named-query): save query text instead of name

### DIFF
--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.spec.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.spec.ts
@@ -1,14 +1,30 @@
 import { QueryInputComponent } from './query-input.component';
-import { MatDialog } from '@angular/material/dialog';
 import { RuleSet, Rule } from 'ngx-query-builder';
 
 describe('QueryInputComponent', () => {
   it('should set default operator when parsing empty query', () => {
-    const component = new QueryInputComponent({} as MatDialog);
+    const component = new QueryInputComponent();
     component.defaultRuleAttribute = 'document';
     const rs: RuleSet = component.parseQuery('');
     const rule = rs.rules[0] as Rule;
     expect(rule.field).toBe('document');
     expect(rule.operator).toBe('contains');
+  });
+
+  it('should save named ruleset text instead of name', () => {
+    const component = new QueryInputComponent();
+    (component as any).config = { fields: {} } as any;
+    const postSpy = jasmine
+      .createSpy('post')
+      .and.returnValue({ subscribe: () => {} } as any);
+    (component as any).http = { post: postSpy, put: jasmine.createSpy('put') };
+    const rs: RuleSet = {
+      condition: 'and',
+      rules: [{ field: 'a', operator: '=', value: 1 }],
+      name: 'TEST',
+    };
+    component.saveNamedRuleset(rs);
+    const payload = postSpy.calls.mostRecent().args[1];
+    expect(payload.text).toBe('a=1');
   });
 });

--- a/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/projects/popup-ngx-query-builder/src/lib/query-input/query-input.component.ts
@@ -383,7 +383,9 @@ export class QueryInputComponent implements OnInit {
   saveNamedRuleset(rs: RuleSet) {
     if (rs.name) {
       this.namedRulesets[rs.name] = JSON.parse(JSON.stringify(rs));
-      const bql = rulesetToBql(rs, this.queryBuilderConfig);
+      const rsClone = JSON.parse(JSON.stringify(rs));
+      delete rsClone.name;
+      const bql = rulesetToBql(rsClone, this.queryBuilderConfig);
       const payload: NamedQuery = {
         name: rs.name,
         text: bql,


### PR DESCRIPTION
## Summary
- save named query text instead of name when confirming query name
- add unit test for saving named ruleset text

## Testing
- `npx ng test --watch=false` *(fails: Directive SortByDirective tests, Selector component tests, missing karma-jasmine)*
- `dotnet test JhipsterSampleApplication.sln` *(fails: BirthdaysControllerIntTest, others)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c45b984883219854844e1b0053d4