### PR TITLE
Rename detail inclusion parameters to includeDetails

### DIFF
--- a/src/JhipsterSampleApplication.Domain.Services/MovieService.cs
+++ b/src/JhipsterSampleApplication.Domain.Services/MovieService.cs
@@ -29,9 +29,9 @@ namespace JhipsterSampleApplication.Domain.Services
             return SearchAsync(request, false, pitId);
         }
 
-        public async Task<ISearchResponse<Movie>> SearchAsync(ISearchRequest request, bool includeDescriptive, string? pitId = null)
+        public async Task<ISearchResponse<Movie>> SearchAsync(ISearchRequest request, bool includeDetails, string? pitId = null)
         {
-            if (!includeDescriptive)
+            if (!includeDetails)
             {
                 request.Source = new SourceFilter { Excludes = new[] { "synopsis" } };
             }
@@ -144,7 +144,7 @@ namespace JhipsterSampleApplication.Domain.Services
             return SearchWithRulesetAsync(ruleset, size, from, sort, false);
         }
 
-        public async Task<ISearchResponse<Movie>> SearchWithRulesetAsync(Ruleset ruleset, int size = 20, int from = 0, IList<ISort>? sort = null, bool includeDescriptive = false)
+        public async Task<ISearchResponse<Movie>> SearchWithRulesetAsync(Ruleset ruleset, int size = 20, int from = 0, IList<ISort>? sort = null, bool includeDetails = false)
         {
             var queryObject = await ConvertRulesetToElasticSearch(ruleset);
             var searchRequest = new SearchRequest<Movie>
@@ -153,7 +153,7 @@ namespace JhipsterSampleApplication.Domain.Services
                 From = from,
                 Query = new QueryContainerDescriptor<Movie>().Raw(queryObject.ToString())
             };
-            if (!includeDescriptive)
+            if (!includeDetails)
             {
                 searchRequest.Source = new SourceFilter { Excludes = new[] { "synopsis" } };
             }

--- a/src/JhipsterSampleApplication.Domain/Services/Interfaces/IMovieService.cs
+++ b/src/JhipsterSampleApplication.Domain/Services/Interfaces/IMovieService.cs
@@ -7,7 +7,7 @@ namespace JhipsterSampleApplication.Domain.Services.Interfaces
 {
     public interface IMovieService : IGenericElasticSearchService<Movie>
     {
-        Task<ISearchResponse<Movie>> SearchAsync(ISearchRequest request, bool includeDescriptive, string? pitId = null);
-        Task<ISearchResponse<Movie>> SearchWithRulesetAsync(Ruleset ruleset, int size = 20, int from = 0, IList<ISort>? sort = null, bool includeDescriptive = false);
+        Task<ISearchResponse<Movie>> SearchAsync(ISearchRequest request, bool includeDetails, string? pitId = null);
+        Task<ISearchResponse<Movie>> SearchWithRulesetAsync(Ruleset ruleset, int size = 20, int from = 0, IList<ISort>? sort = null, bool includeDetails = false);
     }
 }

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/movie/list/movie.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/movie/list/movie.component.ts
@@ -112,8 +112,8 @@ export class MovieComponent implements OnInit, AfterViewInit {
   constructor() {
     const fetchFunction: FetchFunction<IMovie> = (queryParams: any) => {
       // Exclude large descriptive fields by default for grid
-      if (queryParams.includeDescriptive === undefined) {
-        queryParams.includeDescriptive = false;
+      if (queryParams.includeDetails === undefined) {
+        queryParams.includeDetails = false;
       }
       if (queryParams.bqlQuery) {
         const bql = queryParams.bqlQuery;
@@ -493,8 +493,8 @@ export class MovieComponent implements OnInit, AfterViewInit {
             groupData.mode = 'group';
             } else {
               const fetch: FetchFunction<IMovie> = (queryParams: any) => {
-                if (queryParams.includeDescriptive === undefined) {
-                  queryParams.includeDescriptive = false;
+                if (queryParams.includeDetails === undefined) {
+                  queryParams.includeDetails = false;
                 }
                 if (queryParams.bqlQuery) {
                   const bql = queryParams.bqlQuery;
@@ -527,8 +527,8 @@ export class MovieComponent implements OnInit, AfterViewInit {
             groupData.mode = 'group';
             } else {
               const fetch: FetchFunction<IMovie> = (queryParams: any) => {
-                if (queryParams.includeDescriptive === undefined) {
-                  queryParams.includeDescriptive = false;
+                if (queryParams.includeDetails === undefined) {
+                  queryParams.includeDetails = false;
                 }
                 if (queryParams.bqlQuery) {
                   const bql = queryParams.bqlQuery;

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/movie/service/movie.service.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/movie/service/movie.service.ts
@@ -44,14 +44,14 @@ export class MovieService {
       queryString += '*';
     }
 
-    const includeDescriptive = req?.includeDescriptive === true;
+    const includeDetails = req?.includeDetails === true;
     return this.http.get<{
       hits: IMovie[] | any[];
       hitType: string;
       totalHits: number;
       searchAfter: string[];
       pitId: string | null;
-    }>(`${this.searchUrl}?${queryString}&includeDescriptive=${includeDescriptive}`, {
+    }>(`${this.searchUrl}?${queryString}&includeDetails=${includeDetails}`, {
       params: options,
       observe: 'response',
     });
@@ -59,14 +59,14 @@ export class MovieService {
 
   searchWithRuleset(ruleset: any, req?: any): Observable<EntityArrayResponseType> {
     const options = createRequestOption(req);
-    const includeDescriptive = req?.includeDescriptive === true;
+    const includeDetails = req?.includeDetails === true;
     return this.http.post<{
       hits: IMovie[] | any[];
       hitType: string;
       totalHits: number;
       searchAfter: string[];
       pitId: string | null;
-    }>(`${this.rulesetSearchUrl}?includeDescriptive=${includeDescriptive}`, ruleset, {
+    }>(`${this.rulesetSearchUrl}?includeDetails=${includeDetails}`, ruleset, {
       params: options,
       observe: 'response',
     });
@@ -74,14 +74,14 @@ export class MovieService {
 
   searchWithBql(bqlQuery: string, req?: any): Observable<EntityArrayResponseType> {
     const options = createRequestOption(req);
-    const includeDescriptive = req?.includeDescriptive === true;
+    const includeDetails = req?.includeDetails === true;
     return this.http.post<{
       hits: IMovie[] | any[];
       hitType: string;
       totalHits: number;
       searchAfter: string[];
       pitId: string | null;
-    }>(`${this.bqlSearchUrl}?includeDescriptive=${includeDescriptive}`, bqlQuery, {
+    }>(`${this.bqlSearchUrl}?includeDetails=${includeDetails}`, bqlQuery, {
       params: options,
       headers: { 'Content-Type': 'text/plain' },
       observe: 'response',

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/supreme/list/supreme.component.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/supreme/list/supreme.component.ts
@@ -108,8 +108,8 @@ export class SupremeComponent implements OnInit, AfterViewInit {
   constructor() {
     const fetchFunction: FetchFunction<ISupreme> = (queryParams: any) => {
       // Exclude large descriptive fields by default for grid
-      if (queryParams.includeDescriptive === undefined) {
-        queryParams.includeDescriptive = false;
+      if (queryParams.includeDetails === undefined) {
+        queryParams.includeDetails = false;
       }
       if (queryParams.bqlQuery) {
         const bql = queryParams.bqlQuery;
@@ -489,8 +489,8 @@ export class SupremeComponent implements OnInit, AfterViewInit {
             groupData.mode = 'group';
             } else {
               const fetch: FetchFunction<ISupreme> = (queryParams: any) => {
-                if (queryParams.includeDescriptive === undefined) {
-                  queryParams.includeDescriptive = false;
+                if (queryParams.includeDetails === undefined) {
+                  queryParams.includeDetails = false;
                 }
                 if (queryParams.bqlQuery) {
                   const bql = queryParams.bqlQuery;
@@ -523,8 +523,8 @@ export class SupremeComponent implements OnInit, AfterViewInit {
             groupData.mode = 'group';
             } else {
               const fetch: FetchFunction<ISupreme> = (queryParams: any) => {
-                if (queryParams.includeDescriptive === undefined) {
-                  queryParams.includeDescriptive = false;
+                if (queryParams.includeDetails === undefined) {
+                  queryParams.includeDetails = false;
                 }
                 if (queryParams.bqlQuery) {
                   const bql = queryParams.bqlQuery;

--- a/src/JhipsterSampleApplication/ClientApp/src/app/entities/supreme/service/supreme.service.ts
+++ b/src/JhipsterSampleApplication/ClientApp/src/app/entities/supreme/service/supreme.service.ts
@@ -44,14 +44,14 @@ export class SupremeService {
       queryString += '*';
     }
 
-    const includeDescriptive = req?.includeDescriptive === true;
+    const includeDetails = req?.includeDetails === true;
     return this.http.get<{
       hits: ISupreme[] | any[];
       hitType: string;
       totalHits: number;
       searchAfter: string[];
       pitId: string | null;
-    }>(`${this.searchUrl}?${queryString}&includeDescriptive=${includeDescriptive}`, {
+    }>(`${this.searchUrl}?${queryString}&includeDetails=${includeDetails}`, {
       params: options,
       observe: 'response',
     });
@@ -59,14 +59,14 @@ export class SupremeService {
 
   searchWithRuleset(ruleset: any, req?: any): Observable<EntityArrayResponseType> {
     const options = createRequestOption(req);
-    const includeDescriptive = req?.includeDescriptive === true;
+    const includeDetails = req?.includeDetails === true;
     return this.http.post<{
       hits: ISupreme[] | any[];
       hitType: string;
       totalHits: number;
       searchAfter: string[];
       pitId: string | null;
-    }>(`${this.rulesetSearchUrl}?includeDescriptive=${includeDescriptive}`, ruleset, {
+    }>(`${this.rulesetSearchUrl}?includeDetails=${includeDetails}`, ruleset, {
       params: options,
       observe: 'response',
     });
@@ -74,14 +74,14 @@ export class SupremeService {
 
   searchWithBql(bqlQuery: string, req?: any): Observable<EntityArrayResponseType> {
     const options = createRequestOption(req);
-    const includeDescriptive = req?.includeDescriptive === true;
+    const includeDetails = req?.includeDetails === true;
     return this.http.post<{
       hits: ISupreme[] | any[];
       hitType: string;
       totalHits: number;
       searchAfter: string[];
       pitId: string | null;
-    }>(`${this.bqlSearchUrl}?includeDescriptive=${includeDescriptive}`, bqlQuery, {
+    }>(`${this.bqlSearchUrl}?includeDetails=${includeDetails}`, bqlQuery, {
       params: options,
       headers: { 'Content-Type': 'text/plain' },
       observe: 'response',

--- a/src/JhipsterSampleApplication/Controllers/BirthdaysController.cs
+++ b/src/JhipsterSampleApplication/Controllers/BirthdaysController.cs
@@ -131,7 +131,7 @@ namespace JhipsterSampleApplication.Controllers
             [FromQuery] string? sort = null,
             [FromQuery] string? pitId = null,
             [FromQuery] string[]? searchAfter = null,
-            [FromQuery] bool includeWikipedia = false,
+            [FromQuery] bool includeDetails = false,
             [FromQuery] string? view = null,
             [FromQuery] string? category = null,
             [FromQuery] string? secondaryCategory = null)
@@ -146,7 +146,7 @@ namespace JhipsterSampleApplication.Controllers
             JObject queryObject = new JObject(
                 new JProperty("query_string", queryStringObject)
             );
-            return await Search(queryObject, pageSize, from, sort, includeWikipedia, view, category, secondaryCategory, pitId, searchAfter);
+            return await Search(queryObject, pageSize, from, sort, includeDetails, view, category, secondaryCategory, pitId, searchAfter);
         }
 
         /// <summary>
@@ -162,14 +162,14 @@ namespace JhipsterSampleApplication.Controllers
             [FromQuery] string? sort = null,
             [FromQuery] string? pitId = null,
             [FromQuery] string[]? searchAfter = null,
-            [FromQuery] bool includeWikipedia = false,
+            [FromQuery] bool includeDetails = false,
             [FromQuery] string? view = null,
             [FromQuery] string? category = null,
             [FromQuery] string? secondaryCategory = null)
         {
             var ruleset = _mapper.Map<Ruleset>(rulesetDto);
             var queryObject = await _birthdayService.ConvertRulesetToElasticSearch(ruleset);
-            return await Search(queryObject, pageSize, from, sort, includeWikipedia, view, category, secondaryCategory, pitId, searchAfter);
+            return await Search(queryObject, pageSize, from, sort, includeDetails, view, category, secondaryCategory, pitId, searchAfter);
         }
 
         /// <summary>
@@ -183,7 +183,7 @@ namespace JhipsterSampleApplication.Controllers
             [FromQuery] int pageSize = 20,
             [FromQuery] int from = 0,
             [FromQuery] string? sort = null,
-            [FromQuery] bool includeWikipedia = false,
+            [FromQuery] bool includeDetails = false,
             [FromQuery] string? view = null,
             [FromQuery] string? category = null,
             [FromQuery] string? secondaryCategory = null,
@@ -363,7 +363,7 @@ namespace JhipsterSampleApplication.Controllers
                     Dob = b.Dob,
                     IsAlive = b.IsAlive,
                     Text = b.Text,
-                    Wikipedia = includeWikipedia ? b.Wikipedia : null,
+                    Wikipedia = includeDetails ? b.Wikipedia : null,
                     Categories = b.Categories
                 });
             }
@@ -387,7 +387,7 @@ namespace JhipsterSampleApplication.Controllers
             [FromQuery] string? sort = null,
             [FromQuery] string? pitId = null,
             [FromQuery] string[]? searchAfter = null,
-            [FromQuery] bool includeWikipedia = false,
+            [FromQuery] bool includeDetails = false,
             [FromQuery] string? view = null,
             [FromQuery] string? category = null,
             [FromQuery] string? secondaryCategory = null)
@@ -399,12 +399,12 @@ namespace JhipsterSampleApplication.Controllers
             var ruleset = _mapper.Map<Ruleset>(rulesetDto);
             var queryObject = await _birthdayService.ConvertRulesetToElasticSearch(ruleset);
             await _historyService.Save(new History { User = User?.Identity?.Name, Domain = "birthday", Text = bqlQuery });
-            return await Search(queryObject, pageSize, from, sort, includeWikipedia, view, category, secondaryCategory, pitId, searchAfter);
+            return await Search(queryObject, pageSize, from, sort, includeDetails, view, category, secondaryCategory, pitId, searchAfter);
         }
 
         [HttpGet("{id}")]
         [ProducesResponseType(typeof(BirthdayDto), 200)]
-        public async Task<IActionResult> GetById(string id, [FromQuery] bool includeWikipedia = false)
+        public async Task<IActionResult> GetById(string id, [FromQuery] bool includeDetails = false)
         {
             var searchRequest = new SearchRequest<Birthday>
             {
@@ -427,7 +427,7 @@ namespace JhipsterSampleApplication.Controllers
                 Sign = birthday.Sign,
                 Dob = birthday.Dob,
                 IsAlive = birthday.IsAlive ?? false,
-                Wikipedia = includeWikipedia ? birthday.Wikipedia : null,
+                Wikipedia = includeDetails ? birthday.Wikipedia : null,
                 Categories = birthday.Categories
             };
 

--- a/src/JhipsterSampleApplication/Controllers/SupremesController.cs
+++ b/src/JhipsterSampleApplication/Controllers/SupremesController.cs
@@ -185,9 +185,9 @@ namespace JhipsterSampleApplication.Controllers
 			[FromQuery] string? view = null,
 			[FromQuery] string? category = null,
 			[FromQuery] string? secondaryCategory = null,
-			[FromQuery] bool includeDescriptive = false)
+			[FromQuery] bool includeDetails = false)
 		{
-			_logger.LogInformation("Supreme lucene search called. query='{Query}', from={From}, pageSize={PageSize}, sort='{Sort}', view='{View}', category='{Category}', secondaryCategory='{SecondaryCategory}', includeDescriptive={IncludeDescriptive}", query, from, pageSize, sort, view, category, secondaryCategory, includeDescriptive);
+			_logger.LogInformation("Supreme lucene search called. query='{Query}', from={From}, pageSize={PageSize}, sort='{Sort}', view='{View}', category='{Category}', secondaryCategory='{SecondaryCategory}', includeDetails={IncludeDetails}", query, from, pageSize, sort, view, category, secondaryCategory, includeDetails);
 			if (string.IsNullOrWhiteSpace(query))
 			{
 				return BadRequest("Query cannot be empty");
@@ -196,7 +196,7 @@ namespace JhipsterSampleApplication.Controllers
 			JObject queryObject = new JObject(new JProperty("query_string", queryStringObject));
 			try
 			{
-				return await Search(queryObject, pageSize, from, sort, view, category, secondaryCategory, pitId, searchAfter, includeDescriptive);
+				return await Search(queryObject, pageSize, from, sort, view, category, secondaryCategory, pitId, searchAfter, includeDetails);
 			}
 			catch (Exception ex)
 			{
@@ -217,11 +217,11 @@ namespace JhipsterSampleApplication.Controllers
 			[FromQuery] string? view = null,
 			[FromQuery] string? category = null,
 			[FromQuery] string? secondaryCategory = null,
-			[FromQuery] bool includeDescriptive = false)
+			[FromQuery] bool includeDetails = false)
 		{
 			var ruleset = _mapper.Map<Ruleset>(rulesetDto);
 			var queryObject = await _supremeService.ConvertRulesetToElasticSearch(ruleset);
-			return await Search(queryObject, pageSize, from, sort, view, category, secondaryCategory, pitId, searchAfter, includeDescriptive);
+			return await Search(queryObject, pageSize, from, sort, view, category, secondaryCategory, pitId, searchAfter, includeDetails);
 		}
 
 		[HttpPost("search/elasticsearch")]
@@ -236,7 +236,7 @@ namespace JhipsterSampleApplication.Controllers
 			[FromQuery] string? secondaryCategory = null,
 			[FromQuery] string? pitId = null,
 			[FromQuery] string[]? searchAfter = null,
-			[FromQuery] bool includeDescriptive = false)
+			[FromQuery] bool includeDetails = false)
 		{
 			if (!string.IsNullOrEmpty(view))
 			{
@@ -369,7 +369,7 @@ namespace JhipsterSampleApplication.Controllers
                         {
                                 Size = pageSize,
                                 From = from,
-                                Source = includeDescriptive
+                                Source = includeDetails
                                         ? true
                                         : new SourceFilter
                                         {
@@ -492,7 +492,7 @@ namespace JhipsterSampleApplication.Controllers
 			[FromQuery] string? view = null,
                         [FromQuery] string? category = null,
                         [FromQuery] string? secondaryCategory = null,
-                        [FromQuery] bool includeDescriptive = false)
+                        [FromQuery] bool includeDetails = false)
 		{
 			if (string.IsNullOrWhiteSpace(bqlQuery))
 			{
@@ -502,18 +502,18 @@ namespace JhipsterSampleApplication.Controllers
                         var ruleset = _mapper.Map<Ruleset>(rulesetDto);
                         var queryObject = await _supremeService.ConvertRulesetToElasticSearch(ruleset);
                         await _historyService.Save(new History { User = User?.Identity?.Name, Domain = "supreme", Text = bqlQuery });
-                        return await Search(queryObject, pageSize, from, sort, view, category, secondaryCategory, pitId, searchAfter, includeDescriptive);
+                        return await Search(queryObject, pageSize, from, sort, view, category, secondaryCategory, pitId, searchAfter, includeDetails);
                 }
 
 
                 [HttpGet("{id}")]
                 [ProducesResponseType(typeof(SupremeDto), 200)]
-                public async Task<IActionResult> GetById(string id, [FromQuery] bool includeDescriptive = false)
+                public async Task<IActionResult> GetById(string id, [FromQuery] bool includeDetails = false)
                 {
                         var searchRequest = new SearchRequest<Supreme>
                         {
                                 Query = new QueryContainerDescriptor<Supreme>().Term(t => t.Field("_id").Value(id)),
-                                Source = includeDescriptive ? null : new SourceFilter
+                                Source = includeDetails ? null : new SourceFilter
                                 {
                                         Excludes = new[] { "justia_url", "facts_of_the_case", "question", "conclusion" }
                                 }
@@ -533,15 +533,15 @@ namespace JhipsterSampleApplication.Controllers
                                 Docket_Number = s.Docket_Number,
                                 Manner_Of_Jurisdiction = s.Manner_Of_Jurisdiction,
                                 Lower_Court = s.Lower_Court,
-                                Facts_Of_The_Case = includeDescriptive ? s.Facts_Of_The_Case : null,
-                                Question = includeDescriptive ? s.Question : null,
-                                Conclusion = includeDescriptive ? s.Conclusion : null,
+                                Facts_Of_The_Case = includeDetails ? s.Facts_Of_The_Case : null,
+                                Question = includeDetails ? s.Question : null,
+                                Conclusion = includeDetails ? s.Conclusion : null,
                                 Decision = s.Decision,
                                 Description = s.Description,
                                 Dissent = s.Dissent,
                                 Heard_By = s.Heard_By,
                                 Term = s.Term,
-                                Justia_Url = includeDescriptive ? s.Justia_Url : null,
+                                Justia_Url = includeDetails ? s.Justia_Url : null,
                                 Opinion = s.Opinion,
                                 Argument2_Url = s.Argument2_Url,
                                 Appellant = s.Appellant,

--- a/test/JhipsterSampleApplication.Test/Controllers/BirthdayControllerIntTest.cs
+++ b/test/JhipsterSampleApplication.Test/Controllers/BirthdayControllerIntTest.cs
@@ -103,7 +103,7 @@ namespace JhipsterSampleApplication.Test.Controllers
 
             };
             var rawResponse = await _client.PostAsync(
-                "/api/Birthdays/search/elasticsearch?pageSize=20&from=0&includeWikipedia=false",
+                "/api/Birthdays/search/elasticsearch?pageSize=20&from=0&includeDetails=false",
                 TestUtil.ToJsonContent(rawQuery));
             rawResponse.StatusCode.Should().Be(HttpStatusCode.OK);
             var rawContent = await rawResponse.Content.ReadAsStringAsync();


### PR DESCRIPTION
## Summary
- rename includeDescriptive/includeWikipedia parameters to includeDetails across search APIs
- update front-end services and components to use includeDetails flag
- adjust tests for new includeDetails query parameter

## Testing
- `dotnet build`
- `dotnet test` *(fails: Specified argument was out of range)*
- `npm test --prefix src/JhipsterSampleApplication/ClientApp` *(fails: Parsing error: Unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd2cafb108321ad571ff532dd553d