### PR TITLE
refactor: delegate birthday operations to service

### DIFF
--- a/src/JhipsterSampleApplication.Domain/Services/Interfaces/IBirthdayService.cs
+++ b/src/JhipsterSampleApplication.Domain/Services/Interfaces/IBirthdayService.cs
@@ -2,10 +2,19 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using Nest;
 using JhipsterSampleApplication.Domain.Entities;
+using Newtonsoft.Json.Linq;
+using JhipsterSampleApplication.Dto;
 
 namespace JhipsterSampleApplication.Domain.Services.Interfaces
 {
     public interface IBirthdayService : IGenericElasticSearchService<Birthday>
     {
+        Task<string?> GetHtmlByIdAsync(string id);
+        Task<object> Search(JObject elasticsearchQuery, int pageSize = 20, int from = 0, string? sort = null,
+            bool includeDetails = false, string? view = null, string? category = null,
+            string? secondaryCategory = null, string? pitId = null, string[]? searchAfter = null);
+        Task<BirthdayDto?> GetByIdAsync(string id, bool includeDetails = false);
+        Task<SimpleApiResponse> CategorizeAsync(CategorizeRequestDto request);
+        Task<SimpleApiResponse> CategorizeMultipleAsync(CategorizeMultipleRequestDto request);
     }
-} 
+}


### PR DESCRIPTION
## Summary
- move detailed birthday HTML generation to BirthdayService
- centralize search logic inside BirthdayService and simplify controller
- add service methods for retrieving and categorizing birthdays

## Testing
- `dotnet test` *(fails: Expected healthResult.NumberOfNodes to be greater than 0, but found 0; Expected addResp.StatusCode to be HttpStatusCode.OK {value: 200}, but found HttpStatusCode.InternalServerError {value: 500}...)*

------
https://chatgpt.com/codex/tasks/task_e_68bcdbad0e808321a243e2c53da35e8f