### PR TITLE
refactor: centralize BQL query serialization

### DIFF
--- a/src/JhipsterSampleApplication.Domain.Services/MovieBqlService.cs
+++ b/src/JhipsterSampleApplication.Domain.Services/MovieBqlService.cs
@@ -1,8 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text.RegularExpressions;
 using JhipsterSampleApplication.Domain.Entities;
 using JhipsterSampleApplication.Domain.Services.Interfaces;
 using JhipsterSampleApplication.Dto;
@@ -37,74 +34,6 @@ namespace JhipsterSampleApplication.Domain.Services
                 throw new ArgumentNullException(nameof(ruleset));
             }
             return Task.FromResult(QueryAsString(ruleset));
-        }
-
-        private static string QueryAsString(RulesetDto query, bool recurse = false)
-        {
-            var result = new System.Text.StringBuilder();
-            if (query.rules == null) return string.Empty;
-            bool multipleConditions = false;
-            foreach (var r in query.rules)
-            {
-                if (r == null) continue;
-                if (result.Length > 0)
-                {
-                    result.Append(" " + (query.condition == "and" ? "&" : "|") + " ");
-                    multipleConditions = true;
-                }
-                if (!string.IsNullOrEmpty(r.condition))
-                {
-                    result.Append(QueryAsString(r, query.rules.Count > 1));
-                }
-                else if (r.field == "document")
-                {
-                    var valStr = r.value?.ToString() ?? string.Empty;
-                    if (!Regex.IsMatch(valStr, "^[a-zA-Z\\d]+$"))
-                    {
-                        result.Append("\"" + Regex.Replace(valStr, "([\\\"])", "\\$1") + "\"");
-                    }
-                    else
-                    {
-                        result.Append(valStr.ToLower());
-                    }
-                }
-                else
-                {
-                    string op = (r.@operator ?? "=").ToUpper();
-                    string field = r.field ?? "document";
-                    var valStr = r.value?.ToString() ?? string.Empty;
-                    if (op == "IN" || op == "!IN")
-                    {
-                        var values = (r.value as IEnumerable<object>)?.Select(v => v?.ToString() ?? string.Empty).ToArray() ?? Array.Empty<string>();
-                        var escaped = values.Select(v => Regex.IsMatch(v, "^[A-Za-z0-9]+$") ? v : "\"" + Regex.Replace(v, "([\\\"])", "\\$1") + "\"");
-                        result.Append($"{field} {op} (" + string.Join(", ", escaped) + ")");
-                    }
-                    else if (!Regex.IsMatch(valStr, "^[A-Za-z0-9]+$"))
-                    {
-                        result.Append($"{field} {op} \"" + Regex.Replace(valStr, "([\\\"])", "\\$1") + "\"");
-                    }
-                    else
-                    {
-                        result.Append($"{field} {op} {valStr.ToLower()}");
-                    }
-                }
-            }
-            if (query.not)
-            {
-                if (query.rules.Count == 1 && (query.rules[0] as RulesetDto)?.name != null)
-                {
-                    result.Insert(0, "!");
-                }
-                else
-                {
-                    result.Insert(0, "!(").Append(")");
-                }
-            }
-            else if (recurse && multipleConditions)
-            {
-                result.Insert(0, "(").Append(")");
-            }
-            return result.ToString();
         }
     }
 }

--- a/src/JhipsterSampleApplication.Domain.Services/SupremeBqlService.cs
+++ b/src/JhipsterSampleApplication.Domain.Services/SupremeBqlService.cs
@@ -1,8 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using System.Text.RegularExpressions;
-using System.Collections.Generic;
-using System.Linq;
 using JhipsterSampleApplication.Domain.Services.Interfaces;
 using JhipsterSampleApplication.Domain.Entities;
 using JhipsterSampleApplication.Dto;
@@ -31,81 +28,13 @@ namespace JhipsterSampleApplication.Domain.Services
                 }
 
 
-		public override Task<string> Ruleset2Bql(RulesetDto ruleset)
-		{
-			if (ruleset == null)
-			{
-				throw new ArgumentNullException(nameof(ruleset));
-			}
-			return Task.FromResult(QueryAsString(ruleset));
-		}
-
-		private static string QueryAsString(RulesetDto query, bool recurse = false)
-		{
-			var result = new System.Text.StringBuilder();
-			if (query.rules == null) return string.Empty;
-			bool multipleConditions = false;
-			foreach (var r in query.rules)
-			{
-				if (r == null) continue;
-				if (result.Length > 0)
-				{
-					result.Append(" " + (query.condition == "and" ? "&" : "|") + " ");
-					multipleConditions = true;
-				}
-				if (!string.IsNullOrEmpty(r.condition))
-				{
-					result.Append(QueryAsString(r, query.rules.Count > 1));
-				}
-				else if (r.field == "document")
-				{
-					var valStr = r.value?.ToString() ?? string.Empty;
-					if (!Regex.IsMatch(valStr, "^[a-zA-Z\\d]+$"))
-					{
-						result.Append("\"" + Regex.Replace(valStr, "([\\\"])", "\\$1") + "\"");
-					}
-					else
-					{
-						result.Append(valStr.ToLower());
-					}
-				}
-				else
-				{
-					string op = (r.@operator ?? "=").ToUpper();
-					string field = r.field ?? "document";
-					var valStr = r.value?.ToString() ?? string.Empty;
-					if (op == "IN" || op == "!IN")
-					{
-						var values = (r.value as IEnumerable<object>)?.Select(v => v?.ToString() ?? string.Empty).ToArray() ?? Array.Empty<string>();
-						var escaped = values.Select(v => Regex.IsMatch(v, "^[A-Za-z0-9]+$") ? v : "\"" + Regex.Replace(v, "([\\\"])", "\\$1") + "\"");
-						result.Append($"{field} {op} (" + string.Join(", ", escaped) + ")");
-					}
-					else if (!Regex.IsMatch(valStr, "^[A-Za-z0-9]+$"))
-					{
-						result.Append($"{field} {op} \"" + Regex.Replace(valStr, "([\\\"])", "\\$1") + "\"");
-					}
-					else
-					{
-						result.Append($"{field} {op} {valStr.ToLower()}");
-					}
-				}
-			}
-			if (query.not)
-			{
-				if (query.rules.Count == 1 && (query.rules[0] as RulesetDto)?.name != null)
-				{
-					result.Insert(0, "!");
-				}
-				else
-				{
-					result.Insert(0, "!(").Append(")");
-				}
-			}
-			else if (recurse && multipleConditions)
-			{
-				result.Insert(0, "(").Append(")");
-			}
-			return result.ToString();
-		}
-	}
+                public override Task<string> Ruleset2Bql(RulesetDto ruleset)
+                {
+                        if (ruleset == null)
+                        {
+                                throw new ArgumentNullException(nameof(ruleset));
+                        }
+                        return Task.FromResult(QueryAsString(ruleset));
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- consolidate QueryAsString logic in GenericBqlService and expose to subclasses
- have MovieBqlService and SupremeBqlService reuse base QueryAsString

## Testing
- `dotnet test` *(fails: TestBqlOperations, TestViewOperations, TestUncategorizedFirstNameView, TestCreateAndGetBirthday, TestComplexBqlOperations, TestCategorizeMultiple)*
- `npm test` *(fails: Parsing error: Unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68bddd9b1a508321a4966ae40c7bf379