### PR TITLE
Instantiate entity-specific BqlService within controllers

### DIFF
--- a/src/JhipsterSampleApplication/Configuration/ServiceStartup.cs
+++ b/src/JhipsterSampleApplication/Configuration/ServiceStartup.cs
@@ -1,7 +1,5 @@
 using Scrutor;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using JhipsterSampleApplication.Domain.Entities;
 using JhipsterSampleApplication.Domain.Services;
 using JhipsterSampleApplication.Domain.Services.Interfaces;
 
@@ -31,24 +29,6 @@ public static class ServiceStartup
                     .AsImplementedInterfaces()
                     .WithScopedLifetime()
         );
-        services.AddScoped<IBqlService<Birthday>>(sp => new BqlService<Birthday>(
-            sp.GetRequiredService<ILogger<BqlService<Birthday>>>(),
-            sp.GetRequiredService<INamedQueryService>(),
-            BqlService<Birthday>.LoadSpec("birthday"),
-            "birthdays"));
-
-        services.AddScoped<IBqlService<Movie>>(sp => new BqlService<Movie>(
-            sp.GetRequiredService<ILogger<BqlService<Movie>>>(),
-            sp.GetRequiredService<INamedQueryService>(),
-            BqlService<Movie>.LoadSpec("movie"),
-            "movies"));
-
-        services.AddScoped<IBqlService<Supreme>>(sp => new BqlService<Supreme>(
-            sp.GetRequiredService<ILogger<BqlService<Supreme>>>(),
-            sp.GetRequiredService<INamedQueryService>(),
-            BqlService<Supreme>.LoadSpec("supreme"),
-            "supreme"));
-
         return services;
     }
 }

--- a/src/JhipsterSampleApplication/Controllers/BirthdaysController.cs
+++ b/src/JhipsterSampleApplication/Controllers/BirthdaysController.cs
@@ -31,15 +31,20 @@ namespace JhipsterSampleApplication.Controllers
 
         public BirthdaysController(
             IElasticClient elasticClient,
-            IBqlService<Birthday> bqlService,
+            INamedQueryService namedQueryService,
+            ILogger<BqlService<Birthday>> bqlLogger,
             ILogger<BirthdaysController> log,
             IMapper mapper,
             IHistoryService historyService,
             IViewService viewService)
         {
-            _birthdayService = new EntityService<Birthday>("birthdays", "wikipedia", elasticClient, bqlService, viewService);
+            _bqlService = new BqlService<Birthday>(
+                bqlLogger,
+                namedQueryService,
+                BqlService<Birthday>.LoadSpec("birthday"),
+                "birthdays");
+            _birthdayService = new EntityService<Birthday>("birthdays", "wikipedia", elasticClient, _bqlService, viewService);
             _elasticClient = elasticClient;
-            _bqlService = bqlService;
             _log = log;
             _mapper = mapper;
             _historyService = historyService;

--- a/src/JhipsterSampleApplication/Controllers/MoviesController.cs
+++ b/src/JhipsterSampleApplication/Controllers/MoviesController.cs
@@ -29,11 +29,22 @@ namespace JhipsterSampleApplication.Controllers
         private readonly IViewService _viewService;
         private readonly IHistoryService _historyService;
 
-        public MoviesController(IElasticClient elasticClient, IBqlService<Movie> bqlService, IMapper mapper, IViewService viewService, ILogger<MoviesController> logger, IHistoryService historyService)
+        public MoviesController(
+            IElasticClient elasticClient,
+            INamedQueryService namedQueryService,
+            ILogger<BqlService<Movie>> bqlLogger,
+            IMapper mapper,
+            IViewService viewService,
+            ILogger<MoviesController> logger,
+            IHistoryService historyService)
         {
-            _movieService = new EntityService<Movie>("movies", "synopsis", elasticClient, bqlService, viewService);
+            _bqlService = new BqlService<Movie>(
+                bqlLogger,
+                namedQueryService,
+                BqlService<Movie>.LoadSpec("movie"),
+                "movies");
+            _movieService = new EntityService<Movie>("movies", "synopsis", elasticClient, _bqlService, viewService);
             _elasticClient = elasticClient;
-            _bqlService = bqlService;
             _mapper = mapper;
             _viewService = viewService ?? throw new ArgumentNullException(nameof(viewService));
             _logger = logger;

--- a/src/JhipsterSampleApplication/Controllers/SupremesController.cs
+++ b/src/JhipsterSampleApplication/Controllers/SupremesController.cs
@@ -22,7 +22,7 @@ namespace JhipsterSampleApplication.Controllers
 	public class SupremesController : ControllerBase
 	{
                 private readonly IEntityService<Supreme> _supremeService;
-		private readonly IElasticClient _elasticClient;
+                private readonly IElasticClient _elasticClient;
                 private readonly IBqlService<Supreme> _bqlService;
                 private readonly IMapper _mapper;
                 private readonly IViewService _viewService;
@@ -31,15 +31,20 @@ namespace JhipsterSampleApplication.Controllers
 
                 public SupremesController(
                         IElasticClient elasticClient,
-                     IBqlService<Supreme> bqlService,
+                        INamedQueryService namedQueryService,
+                        ILogger<BqlService<Supreme>> bqlLogger,
                         IMapper mapper,
                         IViewService viewService,
                         ILogger<SupremesController> logger,
                         IHistoryService historyService)
                 {
-                        _supremeService = new EntityService<Supreme>("supreme","justia_url,argument2_url,facts_of_the_case,conclusion", elasticClient, bqlService, viewService);
+                        _bqlService = new BqlService<Supreme>(
+                                bqlLogger,
+                                namedQueryService,
+                                BqlService<Supreme>.LoadSpec("supreme"),
+                                "supreme");
+                        _supremeService = new EntityService<Supreme>("supreme","justia_url,argument2_url,facts_of_the_case,conclusion", elasticClient, _bqlService, viewService);
                         _elasticClient = elasticClient;
-                        _bqlService = bqlService;
                         _mapper = mapper;
                         _viewService = viewService ?? throw new ArgumentNullException(nameof(viewService));
                         _logger = logger;


### PR DESCRIPTION
## Summary
- remove entity-specific BqlService registrations from ServiceStartup
- instantiate BqlService in Birthdays, Movies, and Supremes controllers

## Testing
- `dotnet test` *(fails: BirthdaysController integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c24968a80c8321b59363bbf471d244