### PR TITLE
Standardize controller naming and API order

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ To launch your application's tests, from the test/JhipsterSamplepplication.Test 
 
 ```
 DOTNET_USE_POLLING_FILE_WATCHER=1 dotnet test --no-build --logger "console;verbosity=quiet" > raw.log 2>&1
-DOTNET_USE_POLLING_FILE_WATCHER=1 dotnet test --no-build --logger "console;verbosity=quiet" --filter "FullyQualifiedName~BirthdaysControllerIntTest"
+DOTNET_USE_POLLING_FILE_WATCHER=1 dotnet test --no-build --logger "console;verbosity=quiet" --filter "FullyQualifiedName~BirthdayControllerIntTest"
 ```
 
 The results will be available in raw.log

--- a/test/JhipsterSampleApplication.Test/Controllers/BirthdayControllerIntTest.cs
+++ b/test/JhipsterSampleApplication.Test/Controllers/BirthdayControllerIntTest.cs
@@ -18,14 +18,14 @@ using System.Collections.Generic;
 
 namespace JhipsterSampleApplication.Test.Controllers
 {
-    public class BirthdaysControllerIntTest : IClassFixture<WebApplicationFactory<Startup>>
+    public class BirthdayControllerIntTest : IClassFixture<WebApplicationFactory<Startup>>
     {
         private readonly WebApplicationFactory<Startup> _factory;
         private readonly HttpClient _client;
         private readonly IElasticClient _elasticClient;
         private readonly BirthdayDto _birthdayDto;
 
-        public BirthdaysControllerIntTest(WebApplicationFactory<Startup> factory)
+        public BirthdayControllerIntTest(WebApplicationFactory<Startup> factory)
         {
             _factory = factory;
             _client = factory.CreateClient();


### PR DESCRIPTION
## Summary
- rename Movies, Birthdays, and Supremes controllers to singular forms
- order API endpoints consistently across controllers
- update integration test class name for birthday controller

## Testing
- `dotnet test` *(fails: Connection refused to Elasticsearch)*

------
https://chatgpt.com/codex/tasks/task_e_68c2573d4f788321a11c53d423f6963a