### PR TITLE
refactor: use low-level elastic client

### DIFF
--- a/src/JhipsterSampleApplication.Domain/Services/Interfaces/IEntityService.cs
+++ b/src/JhipsterSampleApplication.Domain/Services/Interfaces/IEntityService.cs
@@ -9,15 +9,15 @@ namespace JhipsterSampleApplication.Domain.Services.Interfaces
 {
     public interface IEntityService<T> where T : class
     {
-        Task<ISearchResponse<T>> SearchAsync(ISearchRequest request, bool includeDetails, string? pitId = null);
+        Task<SearchResponse<T>> SearchAsync(object request, bool includeDetails, string? pitId = null);
         Task<IndexResponse> IndexAsync(T document);
         Task<UpdateResponse<T>> UpdateAsync(string id, T document);
         Task<DeleteResponse> DeleteAsync(string id);
         Task<List<string>> GetUniqueFieldValuesAsync(string field);
-        Task<ISearchResponse<T>> SearchWithRulesetAsync(Ruleset ruleset, int size = 20, int from = 0, IList<ISort>? sort = null);
+        Task<SearchResponse<T>> SearchWithRulesetAsync(Ruleset ruleset, int size = 20, int from = 0);
         Task<JObject> ConvertRulesetToElasticSearch(Ruleset rr);
-        Task<List<ViewResultDto>> SearchWithElasticQueryAndViewAsync(JObject queryObject, ViewDto view, int size = 20, int from = 0, IList<ISort>? sort = null);
-        Task<List<ViewResultDto>> SearchUsingViewAsync(ISearchRequest request, ISearchRequest uncategorizedRequest);
+        Task<List<ViewResultDto>> SearchWithElasticQueryAndViewAsync(JObject queryObject, ViewDto view, int size = 20, int from = 0);
+        Task<List<ViewResultDto>> SearchUsingViewAsync(object request, object uncategorizedRequest);
         Task<SimpleApiResponse> CategorizeAsync(CategorizeRequestDto request);
         Task<SimpleApiResponse> CategorizeMultipleAsync(CategorizeMultipleRequestDto request);
     }

--- a/src/JhipsterSampleApplication/Controllers/BirthdaysController.cs
+++ b/src/JhipsterSampleApplication/Controllers/BirthdaysController.cs
@@ -3,6 +3,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Nest;
+using Elasticsearch.Net;
 using JhipsterSampleApplication.Domain.Services;
 using JhipsterSampleApplication.Domain.Services.Interfaces;
 using JhipsterSampleApplication.Domain.Entities;
@@ -42,7 +43,7 @@ namespace JhipsterSampleApplication.Controllers
                 namedQueryService,
                 BqlService<Birthday>.LoadSpec("birthday"),
                 "birthdays");
-            _birthdayService = new EntityService<Birthday>("birthdays", "wikipedia", elasticClient, _bqlService, viewService);
+            _birthdayService = new EntityService<Birthday>("birthdays", "wikipedia", (ElasticLowLevelClient)elasticClient.LowLevel, _bqlService, viewService);
             _elasticClient = elasticClient;
             _log = logger;
             _mapper = mapper;

--- a/src/JhipsterSampleApplication/Controllers/MoviesController.cs
+++ b/src/JhipsterSampleApplication/Controllers/MoviesController.cs
@@ -3,6 +3,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Nest;
+using Elasticsearch.Net;
 using JhipsterSampleApplication.Domain.Services;
 using JhipsterSampleApplication.Domain.Services.Interfaces;
 using JhipsterSampleApplication.Domain.Entities;
@@ -43,7 +44,7 @@ namespace JhipsterSampleApplication.Controllers
                 namedQueryService,
                 BqlService<Movie>.LoadSpec("movie"),
                 "movies");
-            _movieService = new EntityService<Movie>("movies", "synopsis", elasticClient, _bqlService, viewService);
+            _movieService = new EntityService<Movie>("movies", "synopsis", (ElasticLowLevelClient)elasticClient.LowLevel, _bqlService, viewService);
             _elasticClient = elasticClient;
             _log = logger;
             _mapper = mapper;

--- a/src/JhipsterSampleApplication/Controllers/SupremesController.cs
+++ b/src/JhipsterSampleApplication/Controllers/SupremesController.cs
@@ -3,6 +3,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Nest;
+using Elasticsearch.Net;
 using JhipsterSampleApplication.Domain.Services;
 using JhipsterSampleApplication.Domain.Services.Interfaces;
 using JhipsterSampleApplication.Domain.Entities;
@@ -43,7 +44,7 @@ namespace JhipsterSampleApplication.Controllers
                 namedQueryService,
                 BqlService<Supreme>.LoadSpec("supreme"),
                 "supreme");
-            _supremeService = new EntityService<Supreme>("supreme","justia_url,argument2_url,facts_of_the_case,conclusion", elasticClient, _bqlService, viewService);
+            _supremeService = new EntityService<Supreme>("supreme","justia_url,argument2_url,facts_of_the_case,conclusion", (ElasticLowLevelClient)elasticClient.LowLevel, _bqlService, viewService);
             _elasticClient = elasticClient;
             _log = logger;
             _mapper = mapper;

--- a/test/JhipsterSampleApplication.Test/DomainServices/BirthdayServiceRangeQueryTest.cs
+++ b/test/JhipsterSampleApplication.Test/DomainServices/BirthdayServiceRangeQueryTest.cs
@@ -4,7 +4,7 @@ using JhipsterSampleApplication.Domain.Services;
 using JhipsterSampleApplication.Domain.Services.Interfaces;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Nest;
+using Elasticsearch.Net;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json;
 using Xunit;
@@ -17,7 +17,7 @@ public class BirthdayServiceRangeQueryTest
 
     public BirthdayServiceRangeQueryTest()
     {
-        var elasticClient = new Mock<IElasticClient>().Object;
+        var elasticClient = new ElasticLowLevelClient();
         var bqlService = new BqlService<Birthday>(new Mock<ILogger<BqlService<Birthday>>>().Object,
             new Mock<INamedQueryService>().Object, new JObject(), "birthdays");
         var viewService = new Mock<IViewService>().Object;


### PR DESCRIPTION
## Summary
- refactor EntityService to rely on `ElasticLowLevelClient` and raw request bodies
- update controllers, interface and tests to pass low-level client

## Testing
- `dotnet build`
- `dotnet test` *(fails: Expected verifyResp.StatusCode to be HttpStatusCode.OK {value: 200}, but found HttpStatusCode.InternalServerError {value: 500}.)*

------
https://chatgpt.com/codex/tasks/task_e_68c4743235cc8321aebe6b341ce3d7c6