### PR TITLE
refactor: use low-level client for birthdays

### DIFF
--- a/src/JhipsterSampleApplication/Startup.cs
+++ b/src/JhipsterSampleApplication/Startup.cs
@@ -12,6 +12,7 @@ using Newtonsoft.Json;
 using JhipsterSampleApplication.Domain.Services.Interfaces;
 using JhipsterSampleApplication.Domain.Services;
 using Nest;
+using Elasticsearch.Net;
 using JhipsterSampleApplication.Domain.Entities;
 using JhipsterSampleApplication.Domain.Repositories;
 using JhipsterSampleApplication.Infrastructure.Data.Repositories;
@@ -64,6 +65,7 @@ public class Startup : IStartup
 
         var client = new ElasticClient(settings);
         services.AddSingleton<IElasticClient>(client);
+        services.AddSingleton((ElasticLowLevelClient)client.LowLevel);
         services.AddScoped<IViewRepository, ViewRepository>();
         services.AddScoped<IViewService, ViewService>();
         services.AddScoped<ViewInitializationService>();


### PR DESCRIPTION
## Summary
- use ElasticLowLevelClient in birthdays controller
- map cluster health response manually
- expose low-level client in startup

## Testing
- `dotnet test` *(fails: Expected healthResult.Status not to be <null> or empty, but found ""; Expected bqlSearchResponse.StatusCode to be HttpStatusCode.OK {value: 200}, but found HttpStatusCode.BadRequest {value: 400}; Expected verifyResp.StatusCode to be HttpStatusCode.OK {value: 200}, but found HttpStatusCode.InternalServerError {value: 500})*

------
https://chatgpt.com/codex/tasks/task_e_68c47437f2e4832191516c33f73e666e