### PR TITLE
Refactor controllers to use ElasticLowLevelClient

### DIFF
--- a/src/JhipsterSampleApplication.Domain.Services/EntityService .cs
+++ b/src/JhipsterSampleApplication.Domain.Services/EntityService .cs
@@ -33,14 +33,16 @@ public class EntityService<T> : IEntityService<T> where T : class
     /// <summary>
     /// Initializes a new instance of the EntityService
     /// </summary>
-    /// <param name="elasticClient">The Elasticsearch client</param>
+    /// <param name="elasticClient">The low-level Elasticsearch client</param>
     /// <param name="bqlService">The BQL service</param>
     /// <param name="viewService">The View service</param>
-    public EntityService(string indexName, string detailFields, IElasticClient elasticClient, IBqlService<T> bqlService, IViewService viewService)
+    public EntityService(string indexName, string detailFields, ElasticLowLevelClient elasticClient, IBqlService<T> bqlService, IViewService viewService)
     {
         _indexName = indexName ?? throw new ArgumentNullException(nameof(indexName));
         _detailFields = detailFields ?? throw new ArgumentNullException(nameof(detailFields));
-        _elasticClient = elasticClient ?? throw new ArgumentNullException(nameof(elasticClient));
+        if (elasticClient == null) throw new ArgumentNullException(nameof(elasticClient));
+        var settings = new ConnectionSettings(elasticClient.Settings.ConnectionPool, elasticClient.Settings.Connection);
+        _elasticClient = new ElasticClient(settings);
         _bqlService = bqlService ?? throw new ArgumentNullException(nameof(bqlService));
         _viewService = viewService ?? throw new ArgumentNullException(nameof(viewService));
     }

--- a/src/JhipsterSampleApplication/Startup.cs
+++ b/src/JhipsterSampleApplication/Startup.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using JhipsterSampleApplication.Domain.Services.Interfaces;
 using JhipsterSampleApplication.Domain.Services;
-using Nest;
+using Elasticsearch.Net;
 using JhipsterSampleApplication.Domain.Entities;
 using JhipsterSampleApplication.Domain.Repositories;
 using JhipsterSampleApplication.Infrastructure.Data.Repositories;
@@ -49,21 +49,10 @@ public class Startup : IStartup
         string defaultIndex = configuration.GetValue<string>("Elasticsearch:DefaultIndex")!;    
 
         var node = new Uri(url);
-        var settings = new ConnectionSettings(node).DefaultIndex(defaultIndex);
-        bool bDebugging = false;
-        if (bDebugging)
-        {
-            // Enable debugging for Elasticsearch
-            settings = settings.EnableDebugMode()
-                .DisableDirectStreaming()
-                .PrettyJson()
-                .MaximumRetries(2)
-                .RequestTimeout(TimeSpan.FromMinutes(2))
-                .DisablePing();
-        }
-
-        var client = new ElasticClient(settings);
-        services.AddSingleton<IElasticClient>(client);
+        var settings = new ConnectionConfiguration(node).RequestTimeout(TimeSpan.FromMinutes(2));
+        // Additional configuration options can be applied to settings as needed
+        var client = new ElasticLowLevelClient(settings);
+        services.AddSingleton<ElasticLowLevelClient>(client);
         services.AddScoped<IViewRepository, ViewRepository>();
         services.AddScoped<IViewService, ViewService>();
         services.AddScoped<ViewInitializationService>();

--- a/test/JhipsterSampleApplication.Test/Controllers/BirthdayControllerIntTest.cs
+++ b/test/JhipsterSampleApplication.Test/Controllers/BirthdayControllerIntTest.cs
@@ -8,6 +8,7 @@ using JhipsterSampleApplication.Test.Setup;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Newtonsoft.Json;
 using Xunit;
+using Elasticsearch.Net;
 using Nest;
 using JhipsterSampleApplication.Dto;
 using JhipsterSampleApplication.Controllers;
@@ -29,7 +30,8 @@ namespace JhipsterSampleApplication.Test.Controllers
         {
             _factory = factory;
             _client = factory.CreateClient();
-            _elasticClient = factory.Services.GetRequiredService<IElasticClient>();
+            var lowLevel = factory.Services.GetRequiredService<ElasticLowLevelClient>();
+            _elasticClient = new ElasticClient(new ConnectionSettings(lowLevel.Settings.ConnectionPool, lowLevel.Settings.Connection));
 
             // Create a test birthday entity
             _birthdayDto = new BirthdayDto

--- a/test/JhipsterSampleApplication.Test/DomainServices/BirthdayServiceRangeQueryTest.cs
+++ b/test/JhipsterSampleApplication.Test/DomainServices/BirthdayServiceRangeQueryTest.cs
@@ -4,7 +4,7 @@ using JhipsterSampleApplication.Domain.Services;
 using JhipsterSampleApplication.Domain.Services.Interfaces;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Nest;
+using Elasticsearch.Net;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json;
 using Xunit;
@@ -17,7 +17,7 @@ public class BirthdayServiceRangeQueryTest
 
     public BirthdayServiceRangeQueryTest()
     {
-        var elasticClient = new Mock<IElasticClient>().Object;
+        var elasticClient = new ElasticLowLevelClient();
         var bqlService = new BqlService<Birthday>(new Mock<ILogger<BqlService<Birthday>>>().Object,
             new Mock<INamedQueryService>().Object, new JObject(), "birthdays");
         var viewService = new Mock<IViewService>().Object;


### PR DESCRIPTION
## Summary
- Switch Birthdays, Movies, and Supremes controllers to depend on `ElasticLowLevelClient`
- Adjust `EntityService<T>` to build a high-level client from low-level settings
- Register `ElasticLowLevelClient` in startup and update related tests

## Testing
- `dotnet build`
- `dotnet test` *(fails: TestBqlOperations, TestViewOperations, TestUncategorizedFirstNameView, TestCreateAndGetBirthday, TestComplexBqlOperations, TestCategorizeMultiple)*

------
https://chatgpt.com/codex/tasks/task_e_68c4745824508321bbc485ea7d807d43